### PR TITLE
Adds extra compiler args necessary for compiler.

### DIFF
--- a/yt/utilities/lib/spherical_walk.pyx
+++ b/yt/utilities/lib/spherical_walk.pyx
@@ -1,4 +1,5 @@
 # distutils: language = c++
+# distutils: extra_compile_args=["-std=c++11"]
 # distutils: sources = SPHERICAL_VR_SOURCE
 # distutils: include_dirs = LIB_DIR_SPHERICAL_VR
 


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

C++11 expressions are not recognized without this argument. This is true for the Clang compiler at least, and likely others.

<!--If it fixes an open issue, please link to the issue here.-->