### PR TITLE
Changes latitude voxels to projections in XZ plane; previously overlapped with longitude in XY plane

### DIFF
--- a/yt/utilities/lib/spherical_volume_rendering/spherical_volume_rendering_util.cpp
+++ b/yt/utilities/lib/spherical_volume_rendering/spherical_volume_rendering_util.cpp
@@ -1,6 +1,5 @@
 #include "spherical_volume_rendering_util.h"
 
-#include <iostream>
 #include <algorithm>
 #include <array>
 #include <limits>
@@ -8,20 +7,24 @@
 
 #include "floating_point_comparison_util.h"
 
+#include <iostream>
+using namespace std;
+
 namespace svr {
 
+namespace {
 constexpr double DOUBLE_MAX = std::numeric_limits<double>::max();
 
 // The type corresponding to the voxel(s) with the minimum tMax value for a
 // given traversal.
 enum VoxelIntersectionType {
   Radial = 1,
-  Polar = 2,
-  Azimuthal = 3,
-  RadialPolar = 4,
-  RadialAzimuthal = 5,
-  PolarAzimuthal = 6,
-  RadialPolarAzimuthal = 7
+  Lat = 2,
+  Lon = 3,
+  RadialLat = 4,
+  RadialLon = 5,
+  LatLon = 6,
+  RadialLatLon = 7
 };
 
 // The parameters returned by radialHit().
@@ -36,7 +39,7 @@ struct HitParameters {
 };
 
 // Pre-calculated information for the generalized angular hit function, which
-// generalizes azimuthal and polar hits. Since the ray segment is dependent
+// generalizes lon and lat hits. Since the ray segment is dependent
 // solely on time, this is unnecessary to calculate twice for each plane hit
 // function. Here, ray_segment is the difference between P2 and P1.
 struct RaySegment {
@@ -81,41 +84,108 @@ struct RaySegment {
   FreeVec3 ray_segment_;
 };
 
-// A point will lie between two polar voxel boundaries iff the angle between it
-// and the polar boundary intersection points along the circle of max radius is
-// obtuse. Equality represents the case when the point lies on an polar
-// boundary. This is similar for azimuthal boundaries. Since both cases use
-// points in a plane (XY for polar, XZ for azimuthal), this can be generalized
-// to a single function.
-inline int calculateAngularVoxelIDFromPoints(
-    const std::vector<LineSegment> &angular_max, const double p1,
+inline int calculateLatVoxelIDFromPoints(
+    const std::vector<LineSegment> &lat_max, const double p1,
     double p2) noexcept {
+    const int bound_size = lat_max.size() / 2;
+
+    // loop over the first set of array elements for the latitude boundaries
+    // in the right (XZ) plane
   std::size_t i = 0;
-  for (std::size_t j = 1; j < angular_max.size(); ++i, ++j) {
-    const double X_diff = angular_max[i].P1 - angular_max[j].P1;
-    const double Y_diff = angular_max[i].P2 - angular_max[j].P2;
-    const double X_p1_diff = angular_max[i].P1 - p1;
-    const double X_p2_diff = angular_max[i].P2 - p2;
-    const double Y_p1_diff = angular_max[j].P1 - p1;
-    const double Y_p2_diff = angular_max[j].P2 - p2;
+  for (std::size_t j = 1; j < bound_size; ++i, ++j) {
+    const double X_diff = lat_max[i].P1 - lat_max[j].P1;
+    const double Y_diff = lat_max[i].P2 - lat_max[j].P2;
+    const double X_p1_diff = lat_max[i].P1 - p1;
+    const double X_p2_diff = lat_max[i].P2 - p2;
+    const double Y_p1_diff = lat_max[j].P1 - p1;
+    const double Y_p2_diff = lat_max[j].P2 - p2;
+    const double d1d2 = (X_p1_diff * X_p1_diff) + (X_p2_diff * X_p2_diff) +
+                        (Y_p1_diff * Y_p1_diff) + (Y_p2_diff * Y_p2_diff);
+    const double d3 = (X_diff * X_diff) + (Y_diff * Y_diff);
+    if (d1d2 < d3 || svr::isEqual(d1d2, d3)) {
+      return i;
+    }
+  }
+
+  // loop over the second set of array elements for the latitude boundaries
+  // in the left half (XZ) plane
+  std::size_t k = lat_max.size()-1;
+  for (std::size_t j = lat_max.size() - 2;  bound_size-1 < j; --k, --j) {
+    const double X_diff = lat_max[k].P1 - lat_max[j].P1;
+    const double Y_diff = lat_max[k].P2 - lat_max[j].P2;
+    const double X_p1_diff = lat_max[k].P1 - p1;
+    const double X_p2_diff = lat_max[k].P2 - p2;
+    const double Y_p1_diff = lat_max[j].P1 - p1;
+    const double Y_p2_diff = lat_max[j].P2 - p2;
+    const double d1d2 = (X_p1_diff * X_p1_diff) + (X_p2_diff * X_p2_diff) +
+                        (Y_p1_diff * Y_p1_diff) + (Y_p2_diff * Y_p2_diff);
+    const double d3 = (X_diff * X_diff) + (Y_diff * Y_diff);
+    if (d1d2 < d3 || svr::isEqual(d1d2, d3)) {
+      return  (lat_max.size()-1) % k;
+    }
+  }
+
+  return lat_max.size() + 1;
+}
+
+inline int calculateLonVoxelIDFromPoints(
+    const std::vector<LineSegment> &lon_max, const double p1,
+    double p2) noexcept {
+
+  std::size_t i = 0;
+  for (std::size_t j = 1; j < lon_max.size(); ++i, ++j) {
+    const double X_diff = lon_max[i].P1 - lon_max[j].P1;
+    const double Y_diff = lon_max[i].P2 - lon_max[j].P2;
+    const double X_p1_diff = lon_max[i].P1 - p1;
+    const double X_p2_diff = lon_max[i].P2 - p2;
+    const double Y_p1_diff = lon_max[j].P1 - p1;
+    const double Y_p2_diff = lon_max[j].P2 - p2;
     const double d1d2 = (X_p1_diff * X_p1_diff) + (X_p2_diff * X_p2_diff) +
                         (Y_p1_diff * Y_p1_diff) + (Y_p2_diff * Y_p2_diff);
     const double d3 = (X_diff * X_diff) + (Y_diff * Y_diff);
     if (d1d2 < d3 || svr::isEqual(d1d2, d3)) return i;
   }
-  return i;
+  return lon_max.size() + 1;
 }
 
-// Initializes an angular voxel ID. For polar initialization, *_2 represents
-// the y-plane. For azimuthal initialization, it represents the z-plane. If the
+// Returns true if the "step" taken from the current voxel ID remains in
+// the grid bounds.
+inline bool inBoundsLon(const SphericalVoxelGrid &grid, const int step,
+                              const int lon_voxel) noexcept {
+  if (svr::isEqual( grid.sphereMaxBoundLon(), 2 * M_PI)) {return true;}
+  const double min_bound = lon_voxel * grid.deltaPhi();
+  const double max_bound = (lon_voxel + 1) * grid.deltaPhi();
+  const double min_step_val = min_bound + step * grid.deltaPhi();
+  const double min_step = min_step_val < 0 ? 2 * M_PI + min_step_val : min_step_val;
+  const double max_step = max_bound + step * grid.deltaPhi();
+
+  return max_step <= grid.sphereMaxBoundLon() &&
+         min_step >= grid.sphereMinBoundLon() &&
+         min_step <  grid.sphereMaxBoundLon();
+}
+
+// Returns true if the "step" taken from the current voxel ID remains in
+// the grid bounds.
+inline bool inBoundsLat(const SphericalVoxelGrid &grid, const int step,
+                          const int lat_voxel) noexcept {
+  const double radian = (lat_voxel + 1) * grid.deltaTheta();
+  const double angval = radian + step * grid.deltaTheta();
+
+
+  return angval <= grid.sphereMaxBoundLat() &&
+         angval >= grid.sphereMinBoundLat();
+}
+
+// Initializes an angular voxel ID. For lat initialization, *_2 represents
+// the y-plane. For lon initialization, it represents the z-plane. If the
 // number of sections is 1 or the squared euclidean distance of the ray_sphere
 // vector in the given plane is zero, the voxel ID is set to 0. Otherwise, we
 // find the traversal point of the ray and the sphere center with the projected
 // circle given by the entry_radius.
-inline int initializeAngularVoxelID(const SphericalVoxelGrid &grid,
+inline int initializeLonVoxelID(const SphericalVoxelGrid &grid,
                                     std::size_t number_of_sections,
                                     const FreeVec3 &ray_sphere,
-                                    const std::vector<LineSegment> &angular_max,
+                                    const std::vector<LineSegment> &lon_max,
                                     double ray_sphere_2, double grid_sphere_2,
                                     double entry_radius) noexcept {
   if (number_of_sections == 1) return 0;
@@ -125,7 +195,23 @@ inline int initializeAngularVoxelID(const SphericalVoxelGrid &grid,
   const double r = entry_radius / std::sqrt(SED);
   const double p1 = grid.sphereCenter().x() - ray_sphere.x() * r;
   const double p2 = grid_sphere_2 - ray_sphere_2 * r;
-  return calculateAngularVoxelIDFromPoints(angular_max, p1, p2);
+  return calculateLonVoxelIDFromPoints(lon_max, p1, p2);
+}
+
+inline int initializeLatVoxelID(const SphericalVoxelGrid &grid,
+                                    std::size_t number_of_sections,
+                                    const FreeVec3 &ray_sphere,
+                                    const std::vector<LineSegment> &lat_max,
+                                    double ray_sphere_2, double grid_sphere_2,
+                                    double entry_radius) noexcept {
+  if (number_of_sections == 1) return 0;
+  const double SED =
+      ray_sphere.x() * ray_sphere.x() + ray_sphere_2 * ray_sphere_2;
+  if (SED == 0.0) return 0;
+  const double r = entry_radius / std::sqrt(SED);
+  const double p1 = grid.sphereCenter().x() - ray_sphere.x() * r;
+  const double p2 = grid_sphere_2 - ray_sphere_2 * r;
+  return calculateLatVoxelIDFromPoints(lat_max, p1, p2);
 }
 
 // Determines whether a radial hit occurs for the given ray. A radial hit is
@@ -179,13 +265,13 @@ inline HitParameters radialHit(const Ray &ray,
   return {.tMax = DOUBLE_MAX, .tStep = 0};
 }
 
-// A generalized version of the latter half of the polar and azimuthal hit
+// A generalized version of the latter half of the lat and lon hit
 // parameters. Since the only difference is the 2-d plane for which they exist
 // in, this portion can be generalized to a single function. The calculations
 // presented below follow closely the works of [Foley et al, 1996], [O'Rourke,
 // 1998]. Reference:
 // http://geomalgorithms.com/a05-_intersect-1.html#intersect2D_2Segments()
-HitParameters angularHit(
+HitParameters LonHit(
     const svr::SphericalVoxelGrid &grid, const Ray &ray, double perp_uv_min,
     double perp_uv_max, double perp_uw_min, double perp_uw_max,
     double perp_vw_min, double perp_vw_max, const RaySegment &ray_segment,
@@ -225,11 +311,11 @@ HitParameters angularHit(
       t_max = ray_segment.intersectionTimeAt(b, ray);
     }
   }
-
   const bool t_t_max_eq = svr::isEqual(t, t_max);
   const bool t_max_within_bounds = t < t_max && !t_t_max_eq && t_max < max_t;
   const bool t_t_min_eq = svr::isEqual(t, t_min);
   const bool t_min_within_bounds = t < t_min && !t_t_min_eq && t_min < max_t;
+  const int  nphi = grid.numLonSections() - 1;
   if (!t_max_within_bounds && !t_min_within_bounds) {
     return {.tMax = DOUBLE_MAX, .tStep = 0};
   }
@@ -255,7 +341,7 @@ HitParameters angularHit(
           grid.sphereCenter().x() - max_radius_over_plane_length * a;
       const double p2 = sphere_center_2 - max_radius_over_plane_length * b;
       const int next_step = std::abs(
-          current_voxel - calculateAngularVoxelIDFromPoints(P_max, p1, p2));
+          current_voxel - calculateLonVoxelIDFromPoints(P_max, p1, p2));
       return {.tMax = t_max,
               .tStep = ray.direction().x() < 0.0 || ray_direction_2 < 0.0
                            ? next_step
@@ -271,59 +357,136 @@ HitParameters angularHit(
   return {.tMax = DOUBLE_MAX, .tStep = 0};
 }
 
-// Determines whether a polar hit occurs for the given ray. A polar hit is
-// considered an intersection with the ray and a polar section. The polar
-// sections live in the XY plane.
-inline HitParameters polarHit(const Ray &ray,
+HitParameters LatHit(
+    const svr::SphericalVoxelGrid &grid, const Ray &ray, double perp_uv_min,
+    double perp_uv_max, double perp_uw_min, double perp_uw_max,
+    double perp_vw_min, double perp_vw_max, const RaySegment &ray_segment,
+    const std::array<double, 2> &collinear_times, double t, double max_t,
+    double ray_direction_2, double sphere_center_2,
+    const std::vector<svr::LineSegment> &P_max, int current_voxel, bool sym)
+    noexcept {
+  const int ntheta = grid.numLatSections();
+  const bool is_parallel_min = svr::isEqual(perp_uv_min, 0.0);
+  const bool is_collinear_min = is_parallel_min &&
+                                svr::isEqual(perp_uw_min, 0.0) &&
+                                svr::isEqual(perp_vw_min, 0.0);
+  const bool is_parallel_max = svr::isEqual(perp_uv_max, 0.0);
+  const bool is_collinear_max = is_parallel_max &&
+                                svr::isEqual(perp_uw_max, 0.0) &&
+                                svr::isEqual(perp_vw_max, 0.0);
+  double a, b;
+  double t_min = collinear_times[is_collinear_min];
+  bool is_intersect_min = false;
+  if (!is_parallel_min) {
+    const double inv_perp_uv_min = 1.0 / perp_uv_min;
+    a = perp_vw_min * inv_perp_uv_min;
+    b = perp_uw_min * inv_perp_uv_min;
+    if (!((svr::lessThan(a, 0.0) || svr::lessThan(1.0, a)) ||
+          svr::lessThan(b, 0.0) || svr::lessThan(1.0, b))) {
+      is_intersect_min = true;
+      t_min = ray_segment.intersectionTimeAt(b, ray);
+    }
+  }
+  double t_max = collinear_times[is_collinear_max];
+  bool is_intersect_max = false;
+  if (!is_parallel_max) {
+    const double inv_perp_uv_max = 1.0 / perp_uv_max;
+    a = perp_vw_max * inv_perp_uv_max;
+    b = perp_uw_max * inv_perp_uv_max;
+    if (!((svr::lessThan(a, 0.0) || svr::lessThan(1.0, a)) ||
+          svr::lessThan(b, 0.0) || svr::lessThan(1.0, b))) {
+      is_intersect_max = true;
+      t_max = ray_segment.intersectionTimeAt(b, ray);
+    }
+  }
+  const bool t_t_max_eq = svr::isEqual(t, t_max);
+  const bool t_max_within_bounds = t < t_max && !t_t_max_eq && t_max < max_t;
+  const bool t_t_min_eq = svr::isEqual(t, t_min);
+  const bool t_min_within_bounds = t < t_min && !t_t_min_eq && t_min < max_t;
+  if (!t_max_within_bounds && !t_min_within_bounds) {
+    return {.tMax = DOUBLE_MAX, .tStep = 0};
+  }
+  if (is_intersect_max && !is_intersect_min && !is_collinear_min &&
+      t_max_within_bounds) {
+      if (current_voxel - 1 == 2 * ntheta - 1 ||
+          (current_voxel == ntheta - 1 &&
+           svr::isEqual(grid.sphereMaxBoundLat(),M_PI))) {
+        return {.tMax = t_max, .tStep = 0};
+      }
+    return {.tMax = t_max, .tStep = sym ? -1 : 1};
+  }
+  if (is_intersect_min && !is_intersect_max && !is_collinear_max &&
+      t_min_within_bounds) {
+      if (current_voxel == 0 ||
+          (current_voxel - 1 == ntheta &&
+           svr::isEqual(grid.sphereMaxBoundLat(),M_PI))) {
+        return {.tMax = t_min, .tStep = 0};
+      }
+    return {.tMax = t_min, .tStep = sym ? 1 : -1};
+  }
+  if ((is_intersect_min && is_intersect_max) ||
+      (is_intersect_min && is_collinear_max) ||
+      (is_intersect_max && is_collinear_min)) {
+    const bool min_max_eq = svr::isEqual(t_min, t_max);
+    if (min_max_eq && t_min_within_bounds) {
+      const double perturbed_t = 0.1;
+      a = -ray.direction().x() * perturbed_t;
+      b = -ray_direction_2 * perturbed_t;
+      const double max_radius_over_plane_length =
+          grid.sphereMaxRadius() / std::sqrt(a * a + b * b);
+      const double p1 =
+          grid.sphereCenter().x() - max_radius_over_plane_length * a;
+      const double p2 = sphere_center_2 - max_radius_over_plane_length * b;
+      const int next_voxel = calculateLatVoxelIDFromPoints(P_max, p1, p2);
+      const int voxel_id   = 2 * grid.numLatSections() - current_voxel;
+      const int next_step = sym ?  std::abs(voxel_id - next_voxel)  :
+        std::abs(current_voxel - next_voxel);
+
+      return {.tMax = t_max,
+              .tStep = ray.direction().x() < 0.0 || ray_direction_2 < 0.0
+                           ? next_step
+                           : -next_step};
+    }
+    if (t_min_within_bounds && ((t_min < t_max && !min_max_eq) || t_t_max_eq)) {
+      if (current_voxel == 0 ||
+         (current_voxel - 1 == ntheta &&
+          svr::isEqual(grid.sphereMaxBoundLat(),M_PI))) {
+        return {.tMax = t_min, .tStep = 0};
+      }
+      return {.tMax = t_min, .tStep = sym ? 1 : -1};
+    }
+    if (t_max_within_bounds && ((t_max < t_min && !min_max_eq) || t_t_min_eq)) {
+      if (current_voxel - 1 == 2 * ntheta - 1 ||
+          (current_voxel == ntheta - 1 &&
+           svr::isEqual(grid.sphereMaxBoundLat(),M_PI))) {
+        return {.tMax = t_max, .tStep = 0};
+      }
+      return {.tMax = t_max, .tStep = sym ? -1 : 1};
+    }
+  }
+  return {.tMax = DOUBLE_MAX, .tStep = 0};
+}
+
+
+
+// Determines whether a lat hit occurs for the given ray. A lat hit is
+// considered an intersection with the ray and a lat section. The lat
+// sections live in the XZ plane.
+inline HitParameters LatitudeHit(const Ray &ray,
                               const svr::SphericalVoxelGrid &grid,
                               const RaySegment &ray_segment,
                               const std::array<double, 2> &collinear_times,
-                              int current_polar_voxel, double t,
+                              int current_lat_voxel, bool sym, double t,
                               double max_t) noexcept {
   // Calculate the voxel boundary vectors.
-  const BoundVec3 p_one(grid.pMaxPolar(current_polar_voxel).P1,
-                        grid.pMaxPolar(current_polar_voxel).P2, 0.0);
-  const BoundVec3 p_two(grid.pMaxPolar(current_polar_voxel + 1).P1,
-                        grid.pMaxPolar(current_polar_voxel + 1).P2, 0.0);
-  const BoundVec3 *u_min = &grid.centerToPolarBound(current_polar_voxel);
-  const BoundVec3 *u_max = &grid.centerToPolarBound(current_polar_voxel + 1);
-  const FreeVec3 w_min = p_one - ray_segment.P1();
-  const FreeVec3 w_max = p_two - ray_segment.P1();
-  const double perp_uv_min = u_min->x() * ray_segment.vector().y() -
-                             u_min->y() * ray_segment.vector().x();
-  const double perp_uv_max = u_max->x() * ray_segment.vector().y() -
-                             u_max->y() * ray_segment.vector().x();
-  const double perp_uw_min = u_min->x() * w_min.y() - u_min->y() * w_min.x();
-  const double perp_uw_max = u_max->x() * w_max.y() - u_max->y() * w_max.x();
-  const double perp_vw_min = ray_segment.vector().x() * w_min.y() -
-                             ray_segment.vector().y() * w_min.x();
-  const double perp_vw_max = ray_segment.vector().x() * w_max.y() -
-                             ray_segment.vector().y() * w_max.x();
-  return angularHit(grid, ray, perp_uv_min, perp_uv_max, perp_uw_min,
-                    perp_uw_max, perp_vw_min, perp_vw_max, ray_segment,
-                    collinear_times, t, max_t, ray.direction().y(),
-                    grid.sphereCenter().y(), grid.pMaxPolar(),
-                    current_polar_voxel);
-}
-
-// Determines whether an azimuthal hit occurs for the given ray. An azimuthal
-// hit is considered an intersection with the ray and an azimuthal section. The
-// azimuthal sections live in the XZ plane.
-inline HitParameters azimuthalHit(const Ray &ray,
-                                  const svr::SphericalVoxelGrid &grid,
-                                  const RaySegment &ray_segment,
-                                  const std::array<double, 2> &collinear_times,
-                                  int current_azimuthal_voxel, double t,
-                                  double max_t) noexcept {
-  // Calculate the voxel boundary vectors.
-  const BoundVec3 p_one(grid.pMaxAzimuthal(current_azimuthal_voxel).P1, 0.0,
-                        grid.pMaxAzimuthal(current_azimuthal_voxel).P2);
-  const BoundVec3 p_two(grid.pMaxAzimuthal(current_azimuthal_voxel + 1).P1, 0.0,
-                        grid.pMaxAzimuthal(current_azimuthal_voxel + 1).P2);
-  const BoundVec3 *u_min =
-      &grid.centerToAzimuthalBound(current_azimuthal_voxel);
-  const BoundVec3 *u_max =
-      &grid.centerToAzimuthalBound(current_azimuthal_voxel + 1);
+  const BoundVec3 p_one(grid.pMaxLat(current_lat_voxel).P1,
+                        0.0,
+                        grid.pMaxLat(current_lat_voxel).P2);
+  const BoundVec3 p_two(grid.pMaxLat(current_lat_voxel + 1).P1,
+                        0.0,
+                        grid.pMaxLat(current_lat_voxel + 1).P2);
+  const BoundVec3 *u_min = &grid.centerToLatBound(current_lat_voxel);
+  const BoundVec3 *u_max = &grid.centerToLatBound(current_lat_voxel + 1);
   const FreeVec3 w_min = p_one - ray_segment.P1();
   const FreeVec3 w_max = p_two - ray_segment.P1();
   const double perp_uv_min = u_min->x() * ray_segment.vector().z() -
@@ -336,11 +499,50 @@ inline HitParameters azimuthalHit(const Ray &ray,
                              ray_segment.vector().z() * w_min.x();
   const double perp_vw_max = ray_segment.vector().x() * w_max.z() -
                              ray_segment.vector().z() * w_max.x();
-  return angularHit(grid, ray, perp_uv_min, perp_uv_max, perp_uw_min,
+  return LatHit(grid, ray, perp_uv_min, perp_uv_max, perp_uw_min,
+                  perp_uw_max, perp_vw_min, perp_vw_max, ray_segment,
+                  collinear_times, t, max_t, ray.direction().z(),
+                  grid.sphereCenter().z(), grid.pMaxLat(),
+                  current_lat_voxel, sym);
+}
+
+// Determines whether an lon hit occurs for the given ray. An lon
+// hit is considered an intersection with the ray and an lon section. The
+// lon sections live in the XY plane.
+inline HitParameters LongitudeHit(const Ray &ray,
+                                  const svr::SphericalVoxelGrid &grid,
+                                  const RaySegment &ray_segment,
+                                  const std::array<double, 2> &collinear_times,
+                                  int current_lon_voxel, double t,
+                                  double max_t) noexcept {
+  // Calculate the voxel boundary vectors.
+  const BoundVec3 p_one(grid.pMaxLon(current_lon_voxel).P1,
+                        grid.pMaxLon(current_lon_voxel).P2,
+                        0.0);
+  const BoundVec3 p_two(grid.pMaxLon(current_lon_voxel + 1).P1,
+                        grid.pMaxLon(current_lon_voxel + 1).P2,
+                        0.0);
+  const BoundVec3 *u_min =
+      &grid.centerToLonBound(current_lon_voxel);
+  const BoundVec3 *u_max =
+      &grid.centerToLonBound(current_lon_voxel + 1);
+  const FreeVec3 w_min = p_one - ray_segment.P1();
+  const FreeVec3 w_max = p_two - ray_segment.P1();
+  const double perp_uv_min = u_min->x() * ray_segment.vector().y() -
+                             u_min->y() * ray_segment.vector().x();
+  const double perp_uv_max = u_max->x() * ray_segment.vector().y() -
+                             u_max->y() * ray_segment.vector().x();
+  const double perp_uw_min = u_min->x() * w_min.y() - u_min->y() * w_min.x();
+  const double perp_uw_max = u_max->x() * w_max.y() - u_max->y() * w_max.x();
+  const double perp_vw_min = ray_segment.vector().x() * w_min.y() -
+                             ray_segment.vector().y() * w_min.x();
+  const double perp_vw_max = ray_segment.vector().x() * w_max.y() -
+                             ray_segment.vector().y() * w_max.x();
+  return LonHit(grid, ray, perp_uv_min, perp_uv_max, perp_uw_min,
                     perp_uw_max, perp_vw_min, perp_vw_max, ray_segment,
-                    collinear_times, t, max_t, ray.direction().z(),
-                    grid.sphereCenter().z(), grid.pMaxAzimuthal(),
-                    current_azimuthal_voxel);
+                    collinear_times, t, max_t, ray.direction().y(),
+                    grid.sphereCenter().y(), grid.pMaxLon(),
+                    current_lon_voxel);
 }
 
 // Calculates the voxel(s) with the minimal tMax for the next intersection.
@@ -354,80 +556,77 @@ inline HitParameters azimuthalHit(const Ray &ray,
 // 6. tMaxR, tMaxPhi equal intersection.
 // 7. tMaxTheta, tMaxPhi equal intersection.
 // For each case, the following must hold: t < tMax < max_t
-// For reference in shorthand naming:
-//        RP = Radial - Polar
-//        RA = Radial - Azimuthal
-//        PA = Polar  - Azimuthal
+// For reference, uses the following shortform naming:
+//        RP = Radial - Lat
+//        RA = Radial - Lon
+//        PA = Lat  - Lon
 inline VoxelIntersectionType minimumIntersection(
-    const HitParameters &radial, const HitParameters &polar,
-    const HitParameters &azimuthal) noexcept {
-  const bool RP_eq = svr::isEqual(radial.tMax, polar.tMax);
-  const bool RA_eq = svr::isEqual(radial.tMax, azimuthal.tMax);
-  const bool RP_lt = radial.tMax < polar.tMax;
-  const bool RA_lt = radial.tMax < azimuthal.tMax;
+    const HitParameters &radial, const HitParameters &lat,
+    const HitParameters &lon) noexcept {
+  const bool RP_eq = svr::isEqual(radial.tMax, lat.tMax);
+  const bool RA_eq = svr::isEqual(radial.tMax, lon.tMax);
+  const bool RP_lt = radial.tMax < lat.tMax;
+  const bool RA_lt = radial.tMax < lon.tMax;
   if (RP_lt && !RP_eq && RA_lt && !RA_eq) return Radial;
 
-  const bool PA_eq = svr::isEqual(polar.tMax, azimuthal.tMax);
-  const bool PA_lt = polar.tMax < azimuthal.tMax;
-  if (!RP_lt && !RP_eq && PA_lt && !PA_eq) return Polar;
-  if (!PA_lt && !PA_eq && !RA_lt && !RA_eq) return Azimuthal;
-  if (RP_eq && RA_eq) return RadialPolarAzimuthal;
-  if (PA_eq) return PolarAzimuthal;
-  if (RP_eq) return RadialPolar;
-  return RadialAzimuthal;
+  const bool PA_eq = svr::isEqual(lat.tMax, lon.tMax);
+  const bool PA_lt = lat.tMax < lon.tMax;
+  if (!RP_lt && !RP_eq && PA_lt && !PA_eq) return Lat;
+  if (!PA_lt && !PA_eq && !RA_lt && !RA_eq) return Lon;
+  if (RP_eq && RA_eq) return RadialLatLon;
+  if (PA_eq) return LatLon;
+  if (RP_eq) return RadialLat;
+  return RadialLon;
 }
 
 // Initialize an array of values representing the points of intersection between
 // the lines corresponding to voxel boundaries and a given radial voxel in the
-// XY plane and XZ plane. Here, P_* represents these points with a given radius
-// 'current_radius'. The case where the number of polar voxels is equal to the
-// number of azimuthal voxels is also checked to reduce the number of
-// trigonometric and floating point calculations.
+// XY plane and XZ plane. Here, P_* represents these points with a given radius.
+//
+// The calculations used for P_lat are in the XZ plane, where the longitudinal
+// angle phi is 0, so X = rcos(0)sin(theta) and Z = rcos(theta)
+// The calculations used for P_lon are in the XY plane, where the latitudinal
+// angle theta is pi/2, so X = rcos(phi)sin(pi/2) and Y = rsin(phi)sin(pi/2)
 inline void initializeVoxelBoundarySegments(
-    std::vector<svr::LineSegment> &P_polar,
-    std::vector<svr::LineSegment> &P_azimuthal, bool ray_origin_is_outside_grid,
+    std::vector<svr::LineSegment> &P_lat,
+    std::vector<svr::LineSegment> &P_lon, bool ray_origin_is_outside_grid,
     const svr::SphericalVoxelGrid &grid, double current_radius) noexcept {
   if (ray_origin_is_outside_grid) {
-    P_polar = grid.pMaxPolar();
-    P_azimuthal = grid.pMaxAzimuthal();
-    return;
-  }
-  if (grid.numPolarSections() == grid.numAzimuthalSections()) {
-    std::transform(
-        grid.polarTrigValues().cbegin(), grid.polarTrigValues().cend(),
-        P_polar.begin(), P_azimuthal.begin(),
-        [current_radius, &grid](const TrigonometricValues &tv,
-                                LineSegment &polar_LS) -> LineSegment {
-          const double px_value =
-              current_radius * tv.cosine + grid.sphereCenter().x();
-          const double current_radius_times_sin = current_radius * tv.sine;
-          polar_LS = {.P1 = px_value,
-                      .P2 = current_radius_times_sin + grid.sphereCenter().y()};
-          return {.P1 = px_value,
-                  .P2 = current_radius_times_sin + grid.sphereCenter().z()};
-        });
+    P_lat = grid.pMaxLat();
+    P_lon = grid.pMaxLon();
     return;
   }
   std::transform(
-      grid.polarTrigValues().cbegin(), grid.polarTrigValues().cend(),
-      P_polar.begin(),
+      grid.latTrigValues().cbegin(), grid.latTrigValues().cend(),
+      P_lat.begin(),
       [current_radius, &grid](const TrigonometricValues &tv) -> LineSegment {
-        return {.P1 = current_radius * tv.cosine + grid.sphereCenter().x(),
-                .P2 = current_radius * tv.sine + grid.sphereCenter().y()};
+        return {.P1 = current_radius * tv.sine   + grid.sphereCenter().x(),
+                .P2 = current_radius * tv.cosine + grid.sphereCenter().z()};
       });
   std::transform(
-      grid.azimuthalTrigValues().cbegin(), grid.azimuthalTrigValues().cend(),
-      P_azimuthal.begin(),
+      grid.latTrigValues().rbegin(), grid.latTrigValues().rend(),
+      P_lat.begin() + grid.numLatSections() + 1,
+      [current_radius, &grid](const TrigonometricValues &tv) -> LineSegment {
+        return {.P1 = current_radius * -1 * tv.sine   + grid.sphereCenter().x(),
+                .P2 = current_radius      * tv.cosine + grid.sphereCenter().z()};
+      });
+  std::transform(
+      grid.lonTrigValues().cbegin(), grid.lonTrigValues().cend(),
+      P_lon.begin(),
       [current_radius, &grid](const TrigonometricValues &tv) -> LineSegment {
         return {.P1 = current_radius * tv.cosine + grid.sphereCenter().x(),
-                .P2 = current_radius * tv.sine + grid.sphereCenter().z()};
+                .P2 = current_radius * tv.sine   + grid.sphereCenter().y()};
       });
 }
+
+}  // namespace
 
 std::vector<svr::SphericalVoxel> walkSphericalVolume(
     const Ray &ray, const svr::SphericalVoxelGrid &grid,
     double max_t) noexcept {
-  if (max_t <= 0.0) return {};
+  if (max_t <= 0.0) {
+    return {};
+  }
   const FreeVec3 rsv =
       grid.sphereCenter() - ray.pointAtParameter(0.0);  // Ray Sphere Vector.
   const double SED_from_center = rsv.squared_length();
@@ -447,48 +646,49 @@ std::vector<svr::SphericalVoxel> walkSphericalVolume(
   const double v = rsv.dot(ray.direction().to_free());
   const double rsvd_minus_v_squared = rsvd - v * v;
 
-  if (entry_radius_squared <= rsvd_minus_v_squared) return {};
+  if (entry_radius_squared <= rsvd_minus_v_squared) {
+    return {};
+  }
   const double d = std::sqrt(entry_radius_squared - rsvd_minus_v_squared);
   const double t_ray_exit = ray.timeOfIntersectionAt(v + d);
-  if (t_ray_exit < 0.0) return {};
+  if (t_ray_exit < 0.0) {
+   return {};
+}
   const double t_ray_entrance = ray.timeOfIntersectionAt(v - d);
   int current_radial_voxel = radial_entrance_voxel + ray_origin_is_outside_grid;
 
-  //std::cerr << "nr " << grid.numRadialSections() << std::endl;
-  //std::cerr << "np " << grid.numPolarSections() << std::endl;
-  //std::cerr << "na " << grid.numAzimuthalSections() << std::endl;
-  std::vector<svr::LineSegment> P_polar(grid.numPolarSections() + 1);
-  std::vector<svr::LineSegment> P_azimuthal(grid.numAzimuthalSections() + 1);
+  std::vector<svr::LineSegment> P_lat(2 * (grid.numLatSections() + 1));
+  std::vector<svr::LineSegment> P_lon(grid.numLonSections() + 1);
   initializeVoxelBoundarySegments(
-      P_polar, P_azimuthal, ray_origin_is_outside_grid, grid, entry_radius);
+      P_lat, P_lon, ray_origin_is_outside_grid, grid, entry_radius);
 
   const FreeVec3 ray_sphere =
       ray_origin_is_outside_grid
           ? grid.sphereCenter() - ray.pointAtParameter(t_ray_entrance)
           : SED_from_center == 0.0 ? rsv - ray.direction().to_free() : rsv;
 
-  int current_polar_voxel = initializeAngularVoxelID(
-      grid, grid.numPolarSections(), ray_sphere, P_polar, ray_sphere.y(),
-      grid.sphereCenter().y(), entry_radius);
-  if (static_cast<std::size_t>(current_polar_voxel) ==
-      grid.numPolarSections()) {
+  int current_lat_voxel = initializeLatVoxelID(
+      grid, grid.numLatSections(), ray_sphere, P_lat,
+      ray_sphere.z(), grid.sphereCenter().z(), entry_radius);
+  if (static_cast<std::size_t>(current_lat_voxel) >=
+      grid.numLatSections()) {
     return {};
   }
 
-  int current_azimuthal_voxel = initializeAngularVoxelID(
-      grid, grid.numAzimuthalSections(), ray_sphere, P_azimuthal,
-      ray_sphere.z(), grid.sphereCenter().z(), entry_radius);
-  if (static_cast<std::size_t>(current_azimuthal_voxel) ==
-      grid.numAzimuthalSections()) {
+  int current_lon_voxel = initializeLonVoxelID(
+      grid, grid.numLonSections(), ray_sphere, P_lon,
+      ray_sphere.y(), grid.sphereCenter().y(), entry_radius);
+  if (static_cast<std::size_t>(current_lon_voxel) >=
+      grid.numLonSections()) {
     return {};
   }
 
   std::vector<svr::SphericalVoxel> voxels;
-  voxels.reserve(grid.numRadialSections() + grid.numPolarSections() +
-                 grid.numAzimuthalSections());
+  voxels.reserve(grid.numRadialSections() + grid.numLatSections() +
+                 grid.numLonSections());
   voxels.push_back({.radial = current_radial_voxel,
-                    .polar = current_polar_voxel,
-                    .azimuthal = current_azimuthal_voxel});
+                    .lat = current_lat_voxel,
+                    .lon = current_lon_voxel});
 
   double t = t_ray_entrance * ray_origin_is_outside_grid;
   const double unitized_ray_time = max_t * grid.sphereMaxDiameter() +
@@ -509,77 +709,116 @@ std::vector<svr::SphericalVoxel> walkSphericalVolume(
         radialHit(ray, grid, radial_step_has_transitioned, current_radial_voxel,
                   v, rsvd_minus_v_squared, t, max_t);
     ray_segment.updateAtTime(t, ray);
-    const auto polar = polarHit(ray, grid, ray_segment, collinear_times,
-                                current_polar_voxel, t, max_t);
-    const auto azimuthal = azimuthalHit(ray, grid, ray_segment, collinear_times,
-                                        current_azimuthal_voxel, t, max_t);
+    // For latitude, all voxels projected onto the XZ plane have four bounds,
+    // so we call the LatitudeHit function twice.
+    const auto lat1 = LatitudeHit(ray, grid, ray_segment, collinear_times,
+                                current_lat_voxel, false, t, max_t);
+    const int symm_lat_ind = 2 * grid.numLatSections() - current_lat_voxel;
+    const auto lat_symm = LatitudeHit(ray, grid, ray_segment, collinear_times,
+                                  symm_lat_ind, true, t, max_t);
+    const auto sym_bool = lat1.tMax < lat_symm.tMax ? false : true ;
+    const auto lat = !sym_bool ? lat1 : lat_symm ;
+    const auto lon = LongitudeHit(ray, grid, ray_segment, collinear_times,
+                                  current_lon_voxel, t, max_t);
+
     if (current_radial_voxel + radial.tStep == 0 ||
-        (radial.tMax == DOUBLE_MAX && polar.tMax == DOUBLE_MAX &&
-         azimuthal.tMax == DOUBLE_MAX)) {
-        voxels.back().exit_t = t_ray_exit;
+        (radial.tMax == DOUBLE_MAX && lat.tMax == DOUBLE_MAX &&
+         lon.tMax == DOUBLE_MAX)) {
+      voxels.back().exit_t = t_ray_exit;
       return voxels;
     }
     const auto voxel_intersection =
-        minimumIntersection(radial, polar, azimuthal);
+        minimumIntersection(radial, lat, lon);
     switch (voxel_intersection) {
       case Radial: {
         t = radial.tMax;
         current_radial_voxel += radial.tStep;
         break;
       }
-      case Polar: {
-        t = polar.tMax;
-        current_polar_voxel =
-            (current_polar_voxel + polar.tStep) % grid.numPolarSections();
+      case Lat: {
+        t = lat.tMax;
+        if (!inBoundsLat(grid, lat.tStep, current_lat_voxel)) {
+          voxels.back().exit_t = t_ray_exit;
+          return voxels;
+        }
+        current_lat_voxel =
+            (current_lat_voxel + lat.tStep) % grid.numLatSections();
         break;
       }
-      case Azimuthal: {
-        t = azimuthal.tMax;
-        current_azimuthal_voxel = (current_azimuthal_voxel + azimuthal.tStep) %
-                                  grid.numAzimuthalSections();
+      case Lon: {
+        if (!inBoundsLon(grid, lon.tStep,
+                               current_lon_voxel)) {
+          voxels.back().exit_t = t_ray_exit;
+          return voxels;
+        }
+        t = lon.tMax;
+        current_lon_voxel = (current_lon_voxel + lon.tStep) %
+                                  grid.numLonSections();
         break;
       }
-      case RadialPolar: {
+      case RadialLat: {
         t = radial.tMax;
+        if (!inBoundsLat(grid, lat.tStep, current_lat_voxel)) {
+          voxels.back().exit_t = t_ray_exit;
+          return voxels;
+        }
         current_radial_voxel += radial.tStep;
-        current_polar_voxel =
-            (current_polar_voxel + polar.tStep) % grid.numPolarSections();
+        current_lat_voxel =
+            (current_lat_voxel + lat.tStep) % grid.numLatSections();
         break;
       }
-      case RadialAzimuthal: {
+      case RadialLon: {
         t = radial.tMax;
+        if (!inBoundsLon(grid, lon.tStep,
+                               current_lon_voxel)) {
+          voxels.back().exit_t = t_ray_exit;
+          return voxels;
+        }
         current_radial_voxel += radial.tStep;
-        current_azimuthal_voxel = (current_azimuthal_voxel + azimuthal.tStep) %
-                                  grid.numAzimuthalSections();
+        current_lon_voxel = (current_lon_voxel + lon.tStep) %
+                                  grid.numLonSections();
         break;
       }
-      case PolarAzimuthal: {
-        t = polar.tMax;
-        current_polar_voxel =
-            (current_polar_voxel + polar.tStep) % grid.numPolarSections();
-        current_azimuthal_voxel = (current_azimuthal_voxel + azimuthal.tStep) %
-                                  grid.numAzimuthalSections();
+      case LatLon: {
+        t = lat.tMax;
+        if (!inBoundsLon(grid, lon.tStep,
+                               current_lon_voxel) ||
+            !(inBoundsLat(grid, lat.tStep, current_lat_voxel))) {
+
+          voxels.back().exit_t = t_ray_exit;
+          return voxels;
+        }
+        current_lat_voxel =
+            (current_lat_voxel + lat.tStep) % grid.numLatSections();
+        current_lon_voxel = (current_lon_voxel + lon.tStep) %
+                                  grid.numLonSections();
         break;
       }
-      case RadialPolarAzimuthal: {
+      case RadialLatLon: {
         t = radial.tMax;
+        if (!inBoundsLon(grid, lon.tStep,
+                               current_lon_voxel) ||
+            !(inBoundsLat(grid, lat.tStep, current_lat_voxel))) {
+          voxels.back().exit_t = t_ray_exit;
+          return voxels;
+        }
         current_radial_voxel += radial.tStep;
-        current_polar_voxel =
-            (current_polar_voxel + polar.tStep) % grid.numPolarSections();
-        current_azimuthal_voxel = (current_azimuthal_voxel + azimuthal.tStep) %
-                                  grid.numAzimuthalSections();
+        current_lat_voxel =
+            (current_lat_voxel + lat.tStep) % grid.numLatSections();
+        current_lon_voxel = (current_lon_voxel + lon.tStep) %
+                                  grid.numLonSections();
         break;
       }
     }
     if (voxels.back().radial == current_radial_voxel &&
-        voxels.back().polar == current_polar_voxel &&
-        voxels.back().azimuthal == current_azimuthal_voxel) {
+        voxels.back().lat == current_lat_voxel &&
+        voxels.back().lon == current_lon_voxel) {
       continue;
     }
     voxels.back().exit_t = t;
     voxels.push_back({.radial = current_radial_voxel,
-                      .polar = current_polar_voxel,
-                      .azimuthal = current_azimuthal_voxel,
+                      .lat = current_lat_voxel,
+                      .lon = current_lon_voxel,
                       .enter_t = t});
   }
 }
@@ -588,19 +827,19 @@ std::vector<svr::SphericalVoxel> walkSphericalVolume(
 std::vector<svr::SphericalVoxel> walkSphericalVolume(
     double *ray_origin, double *ray_direction, double *min_bound,
     double *max_bound, std::size_t num_radial_voxels,
-    std::size_t num_polar_voxels, std::size_t num_azimuthal_voxels,
+    std::size_t num_lat_voxels, std::size_t num_lon_voxels,
     double *sphere_center, double max_t) noexcept {
   return svr::walkSphericalVolume(
       Ray(BoundVec3(ray_origin[0], ray_origin[1], ray_origin[2]),
           UnitVec3(ray_direction[0], ray_direction[1], ray_direction[2])),
       svr::SphericalVoxelGrid(
           svr::SphereBound{.radial = min_bound[0],
-                           .polar = min_bound[1],
-                           .azimuthal = min_bound[2]},
+                           .lat = min_bound[1],
+                           .lon = min_bound[2]},
           svr::SphereBound{.radial = max_bound[0],
-                           .polar = max_bound[1],
-                           .azimuthal = max_bound[2]},
-          num_radial_voxels, num_polar_voxels, num_azimuthal_voxels,
+                           .lat = max_bound[1],
+                           .lon = max_bound[2]},
+          num_radial_voxels, num_lat_voxels, num_lon_voxels,
           BoundVec3(sphere_center[0], sphere_center[1], sphere_center[2])),
       max_t);
 }

--- a/yt/utilities/lib/spherical_volume_rendering/spherical_volume_rendering_util.h
+++ b/yt/utilities/lib/spherical_volume_rendering/spherical_volume_rendering_util.h
@@ -12,8 +12,10 @@ namespace svr {
 // Represents a spherical voxel coordinate.
 struct SphericalVoxel {
   int radial;
-  int polar;
-  int azimuthal;
+  int lat;
+  int lon;
+
+  // Entrance and exit time into the given voxel.
   double enter_t;
   double exit_t;
 };
@@ -35,7 +37,7 @@ std::vector<SphericalVoxel> walkSphericalVolume(
 std::vector<SphericalVoxel> walkSphericalVolume(
     double *ray_origin, double *ray_direction, double *min_bound,
     double *max_bound, std::size_t num_radial_voxels,
-    std::size_t num_polar_voxels, std::size_t num_azimuthal_voxels,
+    std::size_t num_lat_voxels, std::size_t num_lon_voxels,
     double *sphere_center, double max_t) noexcept;
 
 }  // namespace svr

--- a/yt/utilities/lib/spherical_volume_rendering/spherical_voxel_grid.h
+++ b/yt/utilities/lib/spherical_volume_rendering/spherical_voxel_grid.h
@@ -6,14 +6,13 @@
 #include "vec3.h"
 
 namespace svr {
-constexpr double TAU = 2 * M_PI;
 
 // Represents the boundary for the sphere. This is used to determine the minimum
 // and maximum boundaries for a sectored traversal.
 struct SphereBound {
   double radial;
-  double polar;
-  double azimuthal;
+  double lat;
+  double lon;
 };
 
 // Represents a line segment that is used for the points of intersections
@@ -29,124 +28,213 @@ struct TrigonometricValues {
   double sine;
 };
 
+namespace {
+
+constexpr double TAU = 2 * M_PI;
+
+// Initializes the delta radii squared. These values are used for radial hit
+// calculations in the main spherical volume algorithm. This calculates
+// delta_radius^2 for num_radial_sections + 1 iterations. The delta radius value
+// begins at max_radius, and subtracts delta_radius with each index.
+// For example,
+//
+// Given: num_radial_voxels = 3, max_radius = 6, delta_radius = 2
+// Returns: { 6*6, 4*4, 2*2, 0*0 }
+std::vector<double> initializeDeltaRadiiSquared(
+    const std::size_t num_radial_voxels, const double max_radius,
+    const double delta_radius) {
+  std::vector<double> delta_radii_squared(num_radial_voxels + 1);
+
+  double current_delta_radius = max_radius;
+  std::generate(delta_radii_squared.begin(), delta_radii_squared.end(),
+                [&]() -> double {
+                  const double old_delta_radius = current_delta_radius;
+                  current_delta_radius -= delta_radius;
+                  return old_delta_radius * old_delta_radius;
+                });
+  return delta_radii_squared;
+}
+
+// Returns a vector of TrigonometricValues for the given number of voxels.
+// This begins with min_bound, and increments by a value of delta
+// for num_voxels + 1 iterations. For example,
+//
+// Given: num_voxels = 2, min_bound = 0.0, delta = pi/2
+// Returns: { {.cosine=1.0, .sine=0.0},
+//            {.cosine=0.0, .sine=1.0},
+//            {.cosine=1.0, .sine=0.0} }
+std::vector<TrigonometricValues> initializeTrigonometricValues(
+    const std::size_t num_voxels, const double min_bound, const double delta) {
+  std::vector<TrigonometricValues> trig_values(num_voxels + 1);
+
+  double radians = min_bound;
+  std::generate(trig_values.begin(), trig_values.end(),
+                [&]() -> TrigonometricValues {
+                  const double cos = std::cos(radians);
+                  const double sin = std::sin(radians);
+                  radians += delta;
+                  return {.cosine = cos, .sine = sin};
+                });
+  return trig_values;
+}
+
+// Returns a vector of maximum radius line segments for the given trigonometric
+// values. The following predicate should be true:
+// num_voxels + 1 == trig_values.size() + 1.
+//
+// The LineSegment points P1 and P2 are calculated with the following equations
+// for the latitudinal case:
+// .P1 = max_radius * trig_value.sine + center.x().
+// .P2 = max_radius * trig_value.cosine + center.z().
+// In the latitudinal case, we also add the symmetric sections to the vector.
+std::vector<LineSegment> initializeMaxRadiusLineSegmentsLat(
+    const std::size_t num_voxels, const BoundVec3 &center,
+    const double max_radius,
+    const std::vector<TrigonometricValues> &trig_values) {
+  std::vector<LineSegment> line_segments(2 * (num_voxels + 1));
+  std::transform(trig_values.cbegin(), trig_values.cend(),
+                 line_segments.begin(),
+                 [&](const TrigonometricValues &trig_value) -> LineSegment {
+                   return {.P1 = max_radius * trig_value.sine + center.x(),
+                           .P2 = max_radius * trig_value.cosine + center.z()};
+                 });
+  std::transform(trig_values.rbegin() , trig_values.rend(),
+                  line_segments.begin() + num_voxels + 1,
+                  [&](const TrigonometricValues &trig_value) -> LineSegment {
+                    return {.P1 = max_radius * -1 * trig_value.sine   + center.x(),
+                            .P2 = max_radius      * trig_value.cosine + center.z()};
+                  });
+  return line_segments;
+}
+// The LineSegment points P1 and P2 are calculated with the following equations
+// for the longitudinal case:
+// .P1 = max_radius * trig_value.cosine + center.x().
+// .P2 = max_radius * trig_value.sine + center.y().
+std::vector<LineSegment> initializeMaxRadiusLineSegmentsLon(
+    const std::size_t num_voxels, const BoundVec3 &center,
+    const double max_radius,
+    const std::vector<TrigonometricValues> &trig_values) {
+  std::vector<LineSegment> line_segments(num_voxels + 1);
+  std::transform(trig_values.cbegin(), trig_values.cend(),
+                 line_segments.begin(),
+                 [&](const TrigonometricValues &trig_value) -> LineSegment {
+                   return {.P1 = max_radius * trig_value.cosine + center.x(),
+                           .P2 = max_radius * trig_value.sine + center.y()};
+                 });
+  return line_segments;
+}
+
+// Initializes the vectors determined by the following calculation:
+// sphere center - {X, Y, Z}, WHERE X, Z = P1, P2 for lat voxels.
+std::vector<BoundVec3> initializeCenterToLatPMaxVectors(
+    const std::vector<LineSegment> &line_segments, const BoundVec3 &center) {
+  std::vector<BoundVec3> center_to_pmax_vectors;
+  center_to_pmax_vectors.reserve(line_segments.size());
+
+  for (const auto &points : line_segments) {
+    center_to_pmax_vectors.emplace_back(center -
+                                        FreeVec3(points.P1, 0.0, points.P2));
+  }
+  return center_to_pmax_vectors;
+}
+
+// Similar to above, but uses:
+// sphere center - {X, Y, Z}, WHERE X, Y = P1, P2 for lon voxels.
+std::vector<BoundVec3> initializeCenterToLonPMaxVectors(
+    const std::vector<LineSegment> &line_segments, const BoundVec3 &center) {
+  std::vector<BoundVec3> center_to_pmax_vectors;
+  center_to_pmax_vectors.reserve(line_segments.size());
+
+  for (const auto &points : line_segments) {
+    center_to_pmax_vectors.emplace_back(center -
+                                        FreeVec3(points.P1, points.P2, 0.0));
+  }
+  return center_to_pmax_vectors;
+}
+
+}  // namespace
+
 // Represents a spherical voxel grid used for ray casting. The bounds of the
 // grid are determined by min_bound and max_bound. The deltas are then
 // determined by (max_bound.X - min_bound.X) / num_X_sections. To minimize
 // calculation duplication, many calculations are completed once here and used
 // each time a ray traverses the spherical voxel grid.
+//
+// Note that the grid system currently does not align with one would expect
+// from spherical coordinates. We represent both lat and lon within
+// bounds [0, 2pi].
+// TODO(cgyurgyik): Look into updating lat grid from [0, 2pi] -> [0, pi].
 struct SphericalVoxelGrid {
  public:
   SphericalVoxelGrid(const SphereBound &min_bound, const SphereBound &max_bound,
                      std::size_t num_radial_sections,
-                     std::size_t num_polar_sections,
-                     std::size_t num_azimuthal_sections,
+                     std::size_t num_lat_sections,
+                     std::size_t num_lon_sections,
                      const BoundVec3 &sphere_center)
       : num_radial_sections_(num_radial_sections),
-        num_polar_sections_(num_polar_sections),
-        num_azimuthal_sections_(num_azimuthal_sections),
+        num_lat_sections_(num_lat_sections),
+        num_lon_sections_(num_lon_sections),
         sphere_center_(sphere_center),
+        sphere_max_bound_lat_(max_bound.lat),
+        sphere_min_bound_lat_(min_bound.lat),
+        sphere_max_bound_lon_(max_bound.lon),
+        sphere_min_bound_lon_(min_bound.lon),
+        // TODO(cgyurgyik): Verify we want the sphere_max_radius to simply be
+        // max_bound.radial.
         sphere_max_radius_(max_bound.radial),
         sphere_max_diameter_(sphere_max_radius_ * 2.0),
         delta_radius_((max_bound.radial - min_bound.radial) /
                       num_radial_sections),
-        delta_theta_((max_bound.polar - min_bound.polar) / num_polar_sections),
-        delta_phi_((max_bound.azimuthal - min_bound.azimuthal) /
-                   num_azimuthal_sections) {
-    double current_delta_radius = max_bound.radial - min_bound.radial;
-    delta_radii_sq_.resize(num_radial_sections + 1);
-    std::generate(delta_radii_sq_.begin(), delta_radii_sq_.end(),
-                  [&]() -> double {
-                    const double old_delta_radius = current_delta_radius;
-                    current_delta_radius -= delta_radius_;
-                    return old_delta_radius * old_delta_radius;
-                  });
-    P_max_polar_.resize(num_polar_sections + 1);
-    P_max_azimuthal_.resize(num_azimuthal_sections + 1);
-    center_to_polar_bound_vectors_.reserve(num_polar_sections + 1);
-    center_to_azimuthal_bound_vectors_.reserve(num_azimuthal_sections + 1);
-    if (num_polar_sections == num_azimuthal_sections) {
-      double radians = 0.0;
-      polar_trig_values_.resize(num_polar_sections + 1);
-      std::generate(polar_trig_values_.begin(), polar_trig_values_.end(),
-                    [&]() -> TrigonometricValues {
-                      const double cos = std::cos(radians);
-                      const double sin = std::sin(radians);
-                      radians += delta_theta_;
-                      return {.cosine = cos, .sine = sin};
-                    });
-      std::transform(polar_trig_values_.cbegin(), polar_trig_values_.cend(),
-                     P_max_polar_.begin(), P_max_azimuthal_.begin(),
-                     [&](const TrigonometricValues &tv,
-                         LineSegment &ang_LS) -> LineSegment {
-                       const double px_max_value =
-                           sphere_max_radius_ * tv.cosine + sphere_center.x();
-                       const double max_radius_times_s =
-                           sphere_max_radius_ * tv.sine;
-                       ang_LS = {.P1 = px_max_value,
-                                 .P2 = max_radius_times_s + sphere_center.y()};
-                       return {.P1 = px_max_value,
-                               .P2 = max_radius_times_s + sphere_center.z()};
-                     });
-      for (const auto &points : P_max_polar_) {
-        const BoundVec3 v =
-            sphere_center - FreeVec3(points.P1, points.P2, points.P2);
-        center_to_polar_bound_vectors_.push_back(v);
-        center_to_azimuthal_bound_vectors_.push_back(v);
-      }
-      return;
-    }
-    double radians = 0.0;
-    polar_trig_values_.resize(num_polar_sections + 1);
-    std::generate(polar_trig_values_.begin(), polar_trig_values_.end(),
-                  [&]() -> TrigonometricValues {
-                    const double cos = std::cos(radians);
-                    const double sin = std::sin(radians);
-                    radians += delta_theta_;
-                    return {.cosine = cos, .sine = sin};
-                  });
-    radians = 0.0;
-    azimuthal_trig_values_.resize(num_azimuthal_sections + 1);
-    std::generate(azimuthal_trig_values_.begin(), azimuthal_trig_values_.end(),
-                  [&]() -> TrigonometricValues {
-                    const double cos = std::cos(radians);
-                    const double sin = std::sin(radians);
-                    radians += delta_phi_;
-                    return {.cosine = cos, .sine = sin};
-                  });
-    std::transform(
-        polar_trig_values_.cbegin(), polar_trig_values_.cend(),
-        P_max_polar_.begin(),
-        [&](const TrigonometricValues &ang_tv) -> LineSegment {
-          return {.P1 = sphere_max_radius_ * ang_tv.cosine + sphere_center.x(),
-                  .P2 = sphere_max_radius_ * ang_tv.sine + sphere_center.y()};
-        });
-    std::transform(
-        azimuthal_trig_values_.cbegin(), azimuthal_trig_values_.cend(),
-        P_max_azimuthal_.begin(),
-        [&](const TrigonometricValues &azi_tv) -> LineSegment {
-          return {.P1 = sphere_max_radius_ * azi_tv.cosine + sphere_center.x(),
-                  .P2 = sphere_max_radius_ * azi_tv.sine + sphere_center.z()};
-        });
-    for (const auto &points : P_max_polar_) {
-      center_to_polar_bound_vectors_.emplace_back(
-          sphere_center - FreeVec3(points.P1, points.P2, 0.0));
-    }
-    for (const auto &points : P_max_azimuthal_) {
-      center_to_azimuthal_bound_vectors_.emplace_back(
-          sphere_center - FreeVec3(points.P1, 0.0, points.P2));
-    }
-  }
+        delta_theta_((max_bound.lat - min_bound.lat) / num_lat_sections),
+        delta_phi_((max_bound.lon - min_bound.lon) /
+                   num_lon_sections),
+        // TODO(cgyurgyik): Verify this is actually what we want for
+        // 'max_radius'. The other option is simply using max_bound.radial
+        delta_radii_sq_(initializeDeltaRadiiSquared(
+            num_radial_sections,
+            /*max_radius=*/max_bound.radial - min_bound.radial, delta_radius_)),
+        lat_trig_values_(initializeTrigonometricValues(
+            num_lat_sections, min_bound.lat, delta_theta_)),
+        lon_trig_values_(initializeTrigonometricValues(
+            num_lon_sections, min_bound.lon, delta_phi_)),
+        P_max_lat_(initializeMaxRadiusLineSegmentsLat(
+            num_lat_sections, sphere_center, sphere_max_radius_,
+            lat_trig_values_)),
+        P_max_lon_(initializeMaxRadiusLineSegmentsLon(
+            num_lon_sections, sphere_center, sphere_max_radius_,
+            lon_trig_values_)),
+        center_to_lat_bound_vectors_(
+            initializeCenterToLatPMaxVectors(P_max_lat_, sphere_center)),
+        center_to_lon_bound_vectors_(
+            initializeCenterToLonPMaxVectors(P_max_lon_,
+                                                   sphere_center)) {}
 
   inline std::size_t numRadialSections() const noexcept {
     return this->num_radial_sections_;
   }
 
-  inline std::size_t numPolarSections() const noexcept {
-    return this->num_polar_sections_;
+  inline std::size_t numLatSections() const noexcept {
+    return this->num_lat_sections_;
   }
 
-  inline std::size_t numAzimuthalSections() const noexcept {
-    return this->num_azimuthal_sections_;
+  inline std::size_t numLonSections() const noexcept {
+    return this->num_lon_sections_;
+  }
+
+  inline double sphereMaxBoundLat() const noexcept {
+    return this->sphere_max_bound_lat_;
+  }
+
+  inline double sphereMinBoundLat() const noexcept {
+    return this->sphere_min_bound_lat_;
+  }
+
+  inline double sphereMaxBoundLon() const noexcept {
+    return this->sphere_max_bound_lon_;
+  }
+
+  inline double sphereMinBoundLon() const noexcept {
+    return this->sphere_min_bound_lon_;
   }
 
   inline double sphereMaxRadius() const noexcept {
@@ -163,51 +251,67 @@ struct SphericalVoxelGrid {
 
   inline double deltaRadius() const noexcept { return delta_radius_; }
 
+  inline double deltaPhi() const noexcept { return delta_phi_; }
+
+  inline double deltaTheta() const noexcept { return delta_theta_; }
+
   inline double deltaRadiiSquared(std::size_t i) const noexcept {
     return this->delta_radii_sq_[i];
   }
 
-  inline const LineSegment &pMaxPolar(std::size_t i) const noexcept {
-    return this->P_max_polar_[i];
+  inline const LineSegment &pMaxLat(std::size_t i) const noexcept {
+    return this->P_max_lat_[i];
   }
 
-  inline const std::vector<LineSegment> &pMaxPolar() const noexcept {
-    return this->P_max_polar_;
+  inline const std::vector<LineSegment> &pMaxLat() const noexcept {
+    return this->P_max_lat_;
   }
 
-  inline const BoundVec3 &centerToPolarBound(std::size_t i) const noexcept {
-    return this->center_to_polar_bound_vectors_[i];
+  inline const BoundVec3 &centerToLatBound(std::size_t i) const noexcept {
+    return this->center_to_lat_bound_vectors_[i];
   }
 
-  inline const LineSegment &pMaxAzimuthal(std::size_t i) const noexcept {
-    return this->P_max_azimuthal_[i];
+  inline const LineSegment &pMaxLon(std::size_t i) const noexcept {
+    return this->P_max_lon_[i];
   }
 
-  inline const std::vector<LineSegment> &pMaxAzimuthal() const noexcept {
-    return this->P_max_azimuthal_;
+  inline const std::vector<LineSegment> &pMaxLon() const noexcept {
+    return this->P_max_lon_;
   }
 
-  inline const BoundVec3 &centerToAzimuthalBound(std::size_t i) const noexcept {
-    return this->center_to_azimuthal_bound_vectors_[i];
+  inline const BoundVec3 &centerToLonBound(std::size_t i) const noexcept {
+    return this->center_to_lon_bound_vectors_[i];
   }
 
-  inline const std::vector<TrigonometricValues> &polarTrigValues()
+  inline const std::vector<TrigonometricValues> &latTrigValues()
       const noexcept {
-    return polar_trig_values_;
+    return lat_trig_values_;
   }
 
-  inline const std::vector<TrigonometricValues> &azimuthalTrigValues()
+  inline const std::vector<TrigonometricValues> &lonTrigValues()
       const noexcept {
-    return azimuthal_trig_values_;
+    return lon_trig_values_;
   }
 
  private:
-  // The number of radial, polar, and azimuthal voxels.
-  const std::size_t num_radial_sections_, num_polar_sections_,
-      num_azimuthal_sections_;
+  // The number of radial, lat, and lon voxels.
+  const std::size_t num_radial_sections_, num_lat_sections_,
+      num_lon_sections_;
 
   // The center of the sphere.
   const BoundVec3 sphere_center_;
+
+  // The maximum lat bound of the sphere.
+  const double sphere_max_bound_lat_;
+
+  // The minimum lat bound of the sphere.
+  const double sphere_min_bound_lat_;
+
+  // The maximum lon bound of the sphere.
+  const double sphere_max_bound_lon_;
+
+  // The minimum lon bound of the sphere.
+  const double sphere_min_bound_lon_;
 
   // The maximum radius of the sphere.
   const double sphere_max_radius_;
@@ -218,32 +322,23 @@ struct SphericalVoxelGrid {
   // The maximum sphere radius divided by the number of radial sections.
   const double delta_radius_;
 
-  // 2 * PI divided by X, where X is the number of polar and number of azimuthal
+  // 2 * PI divided by X, where X is the number of lat and number of lon
   // sections respectively.
   const double delta_theta_, delta_phi_;
 
-  // The delta radii squared ranging from 0...num_radial_voxels.
-  std::vector<double> delta_radii_sq_;
+  // The delta radii squared calculated for use in radial hit calculations.
+  const std::vector<double> delta_radii_sq_;
 
-  // The maximum radius line segments for polar voxels.
-  std::vector<LineSegment> P_max_polar_;
+  // The trigonometric values calculated for the lon and lat voxels.
+  const std::vector<TrigonometricValues> lon_trig_values_,
+      lat_trig_values_;
 
-  // The maximum radius line segments for azimuthal voxels.
-  std::vector<LineSegment> P_max_azimuthal_;
+  // The maximum radius line segments for lat and lon voxels.
+  const std::vector<LineSegment> P_max_lat_, P_max_lon_;
 
-  // The trigonometric values for each delta theta.
-  std::vector<TrigonometricValues> polar_trig_values_;
-
-  // The trigonometric values for each delta phi. In the case where delta theta
-  // is equal to delta phi, this is left uninitialized and polar_trig_values_ is
-  // used.
-  std::vector<TrigonometricValues> azimuthal_trig_values_;
-
-  // The vectors represented by sphere_center_ - P_max_polar_[i].
-  std::vector<BoundVec3> center_to_polar_bound_vectors_;
-
-  // The vectors represented by sphere_center_ - P_max_azimuthal_[i].
-  std::vector<BoundVec3> center_to_azimuthal_bound_vectors_;
+  // The vectors represented by the vector sphere center - P_max[i].
+  const std::vector<BoundVec3> center_to_lat_bound_vectors_,
+      center_to_lon_bound_vectors_;
 };
 
 }  // namespace svr


### PR DESCRIPTION
The traversal incorrectly determined voxels for both latitude and longitude by projections onto the XY plane; voxels for latitude should correspond to projections in the XZ plane. The range for latitude is also truncated to ensure the uniqueness of voxels/coordinates: this is achieved by the appropriate projection of a grid of line segments onto the XZ plane in the `initializeMaxRadiusLineSegmentsLat` function of `spherical_voxel_grid.h`. Although the updated files pass updated tests from the original algorithm test library, sufficient testing has not been done through yt. 