### PR TITLE
Particle reader cleanup

### DIFF
--- a/yt/frontends/flash/io.py
+++ b/yt/frontends/flash/io.py
@@ -192,7 +192,7 @@ class IOHandlerFLASHParticle(BaseIOHandler):
         )
         yield ("io", pxyz)
 
-    def _read_data_file(self, data_file, ptf, selector=None):
+    def _read_particle_data_file(self, data_file, ptf, selector=None):
         px, py, pz = self._position_fields
         p_fields = self._handle["/tracer particles"]
         si, ei = data_file.start, data_file.end

--- a/yt/frontends/flash/io.py
+++ b/yt/frontends/flash/io.py
@@ -219,17 +219,8 @@ class IOHandlerFLASHParticle(BaseIOHandler):
         return data_return
 
     def _read_particle_fields(self, chunks, ptf, selector):
-        chunks = list(chunks)
-        data_files = set()
         assert len(ptf) == 1
-        for chunk in chunks:
-            for obj in chunk.objs:
-                data_files.update(obj.data_files)
-
-        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
-
-            data_file_data = self._read_datafile(data_file, ptf, selector)
-            yield from data_file_data.items()
+        yield from super()._read_particle_fields(chunks, ptf, selector)
 
     _pcount = None
 

--- a/yt/frontends/flash/io.py
+++ b/yt/frontends/flash/io.py
@@ -192,7 +192,7 @@ class IOHandlerFLASHParticle(BaseIOHandler):
         )
         yield ("io", pxyz)
 
-    def _read_datafile(self, data_file, ptf, selector=None):
+    def _read_data_file(self, data_file, ptf, selector=None):
         px, py, pz = self._position_fields
         p_fields = self._handle["/tracer particles"]
         si, ei = data_file.start, data_file.end

--- a/yt/frontends/flash/io.py
+++ b/yt/frontends/flash/io.py
@@ -192,7 +192,7 @@ class IOHandlerFLASHParticle(BaseIOHandler):
         )
         yield ("io", pxyz)
 
-    def _read_datafile(self, data_file, ptf, selector):
+    def _read_datafile(self, data_file, ptf, selector=None):
         px, py, pz = self._position_fields
         p_fields = self._handle["/tracer particles"]
         si, ei = data_file.start, data_file.end

--- a/yt/frontends/gadget/io.py
+++ b/yt/frontends/gadget/io.py
@@ -160,7 +160,7 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
             hsml[:] = ds
             return hsml
 
-    def _read_data_file(self, data_file, ptf, selector=None):
+    def _read_particle_data_file(self, data_file, ptf, selector=None):
         si, ei = data_file.start, data_file.end
 
         data_return = {}
@@ -382,7 +382,7 @@ class IOHandlerGadgetBinary(IOHandlerSPH):
                 yield ptype, (pos[:, 0], pos[:, 1], pos[:, 2]), hsml
             f.close()
 
-    def _read_data_file(self, data_file, ptf, selector=None):
+    def _read_particle_data_file(self, data_file, ptf, selector=None):
         return_data = {}
         poff = data_file.field_offsets
         tp = data_file.total_particles

--- a/yt/frontends/gadget/io.py
+++ b/yt/frontends/gadget/io.py
@@ -160,7 +160,7 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
             hsml[:] = ds
             return hsml
 
-    def _read_datafile(self, data_file, ptf, selector=None):
+    def _read_data_file(self, data_file, ptf, selector=None):
         si, ei = data_file.start, data_file.end
 
         data_return = {}
@@ -382,7 +382,7 @@ class IOHandlerGadgetBinary(IOHandlerSPH):
                 yield ptype, (pos[:, 0], pos[:, 1], pos[:, 2]), hsml
             f.close()
 
-    def _read_datafile(self, data_file, ptf, selector=None):
+    def _read_data_file(self, data_file, ptf, selector=None):
         return_data = {}
         poff = data_file.field_offsets
         tp = data_file.total_particles

--- a/yt/frontends/gadget/io.py
+++ b/yt/frontends/gadget/io.py
@@ -382,7 +382,7 @@ class IOHandlerGadgetBinary(IOHandlerSPH):
                 yield ptype, (pos[:, 0], pos[:, 1], pos[:, 2]), hsml
             f.close()
 
-    def _read_datafile(self, data_file, ptf, selector):
+    def _read_datafile(self, data_file, ptf, selector=None):
         return_data = {}
         poff = data_file.field_offsets
         tp = data_file.total_particles

--- a/yt/frontends/stream/io.py
+++ b/yt/frontends/stream/io.py
@@ -132,7 +132,7 @@ class StreamParticleIOHandler(BaseParticleIOHandler):
             psize[ptype] += selector.count_points(x, y, z, hsml)
         return psize
 
-    def _read_datafile(self, data_file, ptf, selector=None):
+    def _read_data_file(self, data_file, ptf, selector=None):
 
         return_data = {}
         f = self.fields[data_file.filename]

--- a/yt/frontends/stream/io.py
+++ b/yt/frontends/stream/io.py
@@ -132,7 +132,7 @@ class StreamParticleIOHandler(BaseParticleIOHandler):
             psize[ptype] += selector.count_points(x, y, z, hsml)
         return psize
 
-    def _read_data_file(self, data_file, ptf, selector=None):
+    def _read_particle_data_file(self, data_file, ptf, selector=None):
 
         return_data = {}
         f = self.fields[data_file.filename]

--- a/yt/frontends/stream/io.py
+++ b/yt/frontends/stream/io.py
@@ -132,7 +132,7 @@ class StreamParticleIOHandler(BaseParticleIOHandler):
             psize[ptype] += selector.count_points(x, y, z, hsml)
         return psize
 
-    def _read_datafile(self, data_file, ptf, selector):
+    def _read_datafile(self, data_file, ptf, selector=None):
 
         return_data = {}
         f = self.fields[data_file.filename]

--- a/yt/frontends/swift/io.py
+++ b/yt/frontends/swift/io.py
@@ -75,7 +75,7 @@ class IOHandlerSwift(IOHandlerSPH):
             hsml = hsml.astype("float64", copy=False)
             return hsml
 
-    def _read_datafile(self, sub_file, ptf, selector):
+    def _read_datafile(self, sub_file, ptf, selector=None):
         # note: this frontend uses the variable name and terminology sub_file.
         # other frontends use data_file with the understanding that it may
         # actually be a sub_file, hence the super()._read_datafile is called

--- a/yt/frontends/swift/io.py
+++ b/yt/frontends/swift/io.py
@@ -75,7 +75,7 @@ class IOHandlerSwift(IOHandlerSPH):
             hsml = hsml.astype("float64", copy=False)
             return hsml
 
-    def _read_datafile(self, sub_file, ptf, selector=None):
+    def _read_data_file(self, sub_file, ptf, selector=None):
         # note: this frontend uses the variable name and terminology sub_file.
         # other frontends use data_file with the understanding that it may
         # actually be a sub_file, hence the super()._read_datafile is called

--- a/yt/frontends/swift/io.py
+++ b/yt/frontends/swift/io.py
@@ -75,7 +75,7 @@ class IOHandlerSwift(IOHandlerSPH):
             hsml = hsml.astype("float64", copy=False)
             return hsml
 
-    def _read_data_file(self, sub_file, ptf, selector=None):
+    def _read_particle_data_file(self, sub_file, ptf, selector=None):
         # note: this frontend uses the variable name and terminology sub_file.
         # other frontends use data_file with the understanding that it may
         # actually be a sub_file, hence the super()._read_datafile is called

--- a/yt/frontends/tipsy/io.py
+++ b/yt/frontends/tipsy/io.py
@@ -151,7 +151,7 @@ class IOHandlerTipsyBinary(IOHandlerSPH):
     def _get_smoothing_length(self, data_file, dtype, shape):
         return self._read_smoothing_length(data_file, shape[0])
 
-    def _read_datafile(self, data_file, ptf, selector):
+    def _read_datafile(self, data_file, ptf, selector=None):
 
         return_data = {}
 

--- a/yt/frontends/tipsy/io.py
+++ b/yt/frontends/tipsy/io.py
@@ -151,7 +151,7 @@ class IOHandlerTipsyBinary(IOHandlerSPH):
     def _get_smoothing_length(self, data_file, dtype, shape):
         return self._read_smoothing_length(data_file, shape[0])
 
-    def _read_data_file(self, data_file, ptf, selector=None):
+    def _read_particle_data_file(self, data_file, ptf, selector=None):
 
         return_data = {}
 

--- a/yt/frontends/tipsy/io.py
+++ b/yt/frontends/tipsy/io.py
@@ -151,7 +151,7 @@ class IOHandlerTipsyBinary(IOHandlerSPH):
     def _get_smoothing_length(self, data_file, dtype, shape):
         return self._read_smoothing_length(data_file, shape[0])
 
-    def _read_datafile(self, data_file, ptf, selector=None):
+    def _read_data_file(self, data_file, ptf, selector=None):
 
         return_data = {}
 

--- a/yt/utilities/io_handler.py
+++ b/yt/utilities/io_handler.py
@@ -175,6 +175,11 @@ class BaseIOHandler:
             psize[ptype] += selector.count_points(x, y, z, 0.0)
         return psize
 
+    def _read_datafile(self, data_file, ptf, selector):
+        # each frontend needs to implement this: read from a data_file object
+        # and return a dict of fields for that data_file
+        raise NotImplementedError
+
     def _read_particle_selection(
         self, chunks, selector, fields: typing.List[ParticleFieldTuple]
     ) -> FieldReturnValues:

--- a/yt/utilities/io_handler.py
+++ b/yt/utilities/io_handler.py
@@ -241,6 +241,19 @@ class BaseIOHandler:
             rv[field_f] = rv[field_f][: ind[field_f]]
         return rv
 
+    def _read_particle_fields(self, chunks, ptf, selector):
+        # Now we have all the sizes, and we can allocate
+        data_files = set()
+        for chunk in chunks:
+            for obj in chunk.objs:
+                data_files.update(obj.data_files)
+        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
+            data_file_data = self._read_datafile(data_file, ptf, selector)
+            # temporary trickery so it's still an iterator, need to adjust
+            # the io_handler.BaseIOHandler.read_particle_selection() method
+            # to not use an iterator.
+            yield from data_file_data.items()
+
 
 # As a note: we don't *actually* want this to be how it is forever.  There's no
 # reason we need to have the fluid and particle IO handlers separated.  But,

--- a/yt/utilities/io_handler.py
+++ b/yt/utilities/io_handler.py
@@ -175,7 +175,7 @@ class BaseIOHandler:
             psize[ptype] += selector.count_points(x, y, z, 0.0)
         return psize
 
-    def _read_data_file(self, data_file, ptf, selector=None):
+    def _read_particle_data_file(self, data_file, ptf, selector=None):
         # each frontend needs to implement this: read from a data_file object
         # and return a dict of fields for that data_file
         raise NotImplementedError
@@ -248,7 +248,7 @@ class BaseIOHandler:
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
         for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
-            data_file_data = self._read_data_file(data_file, ptf, selector)
+            data_file_data = self._read_particle_data_file(data_file, ptf, selector)
             # temporary trickery so it's still an iterator, need to adjust
             # the io_handler.BaseIOHandler.read_particle_selection() method
             # to not use an iterator.

--- a/yt/utilities/io_handler.py
+++ b/yt/utilities/io_handler.py
@@ -175,7 +175,7 @@ class BaseIOHandler:
             psize[ptype] += selector.count_points(x, y, z, 0.0)
         return psize
 
-    def _read_datafile(self, data_file, ptf, selector=None):
+    def _read_data_file(self, data_file, ptf, selector=None):
         # each frontend needs to implement this: read from a data_file object
         # and return a dict of fields for that data_file
         raise NotImplementedError
@@ -248,7 +248,7 @@ class BaseIOHandler:
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
         for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
-            data_file_data = self._read_datafile(data_file, ptf, selector)
+            data_file_data = self._read_data_file(data_file, ptf, selector)
             # temporary trickery so it's still an iterator, need to adjust
             # the io_handler.BaseIOHandler.read_particle_selection() method
             # to not use an iterator.

--- a/yt/utilities/io_handler.py
+++ b/yt/utilities/io_handler.py
@@ -175,7 +175,7 @@ class BaseIOHandler:
             psize[ptype] += selector.count_points(x, y, z, 0.0)
         return psize
 
-    def _read_datafile(self, data_file, ptf, selector):
+    def _read_datafile(self, data_file, ptf, selector=None):
         # each frontend needs to implement this: read from a data_file object
         # and return a dict of fields for that data_file
         raise NotImplementedError


### PR DESCRIPTION
This adds a `_read_data_file` method to each particle frontend's `io` class that specifies how to read from a single `data_file` object. These were written by copying the appropriate code from each frontend's  `_read_particle_fields` implementation. No real changes to that, except that I added checks so that the `selector` variable can be `None`. This is to facilitate transitioning to dask, so that we can call the same `_read_data_file` without a `selector` argument and then later apply the selector to the chunk. When we're ready to fully move to a dask read, we can remove the `selector` argument and the use of the `mask` array in `_read_data_file`.

After writing all the new `_read_data_file` methods, `_read_particle_fields` became identical between the frontends, so I moved that to the `BaseIOHandler` class. Note some trickery remains in `read_particle_fields` so that it is still an iterator. A subsequent PR will address that...