### PR TITLE
Gadget HDF refactor

### DIFF
--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -578,7 +578,7 @@ class GadgetHDF5File(ParticleFile):
         else:
             v = handle[f"/{ptype}/{field_name}"][self.start : self.end, ...]
 
-        if col:
+        if col is not None:
             # extract the column if appropriate for this field
             v = v[:, col]
 

--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -562,7 +562,7 @@ class GadgetDataset(SPHDataset):
 
 class GadgetHDF5File(ParticleFile):
 
-    fields_with_cols = ["Metallicity_", "PassiveScalars_", "Chemistry_", "GFM_Metals_"]
+    _fields_with_cols = ["Metallicity_", "PassiveScalars_", "Chemistry_", "GFM_Metals_"]
 
     def _read_field(self, ptype, field_name, handle=None):
 
@@ -586,12 +586,12 @@ class GadgetHDF5File(ParticleFile):
 
     def _sanitize_field_col(self, field_name: str):
 
-        if any(field_name.startswith(c) for c in self.fields_with_cols):
+        if any(field_name.startswith(c) for c in self._fields_with_cols):
             rc = field_name.rsplit("_", 1)
             col = int(rc[-1])
             rfield = rc[:-1]
 
-            if rfield == "Chemistry":
+            if rfield.startswith("Chemistry"):
                 rfield = rfield + "Abundances"
 
             return rfield, col

--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -562,14 +562,14 @@ class GadgetDataset(SPHDataset):
 
 class GadgetHDF5File(ParticleFile):
 
-    _fields_with_cols = ["Metallicity_", "PassiveScalars_", "Chemistry_", "GFM_Metals_"]
+    _fields_with_cols = ("Metallicity_", "PassiveScalars_", "Chemistry_", "GFM_Metals_")
 
     def _read_field(self, ptype, field_name, handle=None):
 
         field_name, col = self._sanitize_field_col(field_name)
 
         if self.total_particles[ptype] == 0:
-            # consider returning an empty array here instead of None
+            # TODO: consider returning an empty array here instead of None
             return
 
         if not handle:

--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -561,15 +561,45 @@ class GadgetDataset(SPHDataset):
 
 
 class GadgetHDF5File(ParticleFile):
+
+    fields_with_cols = ["Metallicity_", "PassiveScalars_", "Chemistry_", "GFM_Metals_"]
+
     def _read_field(self, ptype, field_name, handle=None):
+
+        field_name, col = self._sanitize_field_col(field_name)
+
         if self.total_particles[ptype] == 0:
+            # consider returning an empty array here instead of None
             return
+
         if not handle:
             with self.transaction as handle:
                 v = handle[f"/{ptype}/{field_name}"][self.start : self.end, ...]
         else:
             v = handle[f"/{ptype}/{field_name}"][self.start : self.end, ...]
+
+        if col:
+            # extract the column if appropriate for this field
+            v = v[:, col]
+
         return v
+
+    def _sanitize_field_col(self, field_name: str):
+
+        if any(field_name.startswith(c) for c in self.fields_with_cols):
+            rc = field_name.split("_")
+            col = int(rc[-1])
+            rfield = rc[0]
+
+            if rfield == "Chemistry":
+                rfield = rfield + "Abundances"
+
+            return rfield, col
+
+        if field_name in self.io._element_names:
+            return "ElementAbundance/" + field_name, None
+
+        return field_name, None
 
     @property
     @contextlib.contextmanager

--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -587,9 +587,9 @@ class GadgetHDF5File(ParticleFile):
     def _sanitize_field_col(self, field_name: str):
 
         if any(field_name.startswith(c) for c in self.fields_with_cols):
-            rc = field_name.split("_")
+            rc = field_name.rsplit("_", 1)
             col = int(rc[-1])
-            rfield = rc[0]
+            rfield = rc[:-1]
 
             if rfield == "Chemistry":
                 rfield = rfield + "Abundances"

--- a/yt/frontends/gadget/io.py
+++ b/yt/frontends/gadget/io.py
@@ -156,7 +156,6 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
             if ds is None:
                 return np.empty(0, dtype=position_dtype)
 
-        # ds may be None
         dt = ds.dtype.newbyteorder("N")  # Native
         if position_dtype is not None and dt < position_dtype:
             # Sometimes positions are stored in double precision
@@ -188,7 +187,7 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
                     )
                     if ptype == "PartType0":
                         hsmls = self._get_smoothing_length(
-                            data_file, coords.dtype, coords.shape
+                            data_file, coords.dtype, coords.shape, handle
                         ).astype("float64")
                     else:
                         hsmls = 0.0
@@ -219,6 +218,7 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
                                 data_file,
                                 coords.dtype,
                                 coords.shape,
+                                handle,
                             ).astype("float64")
                         data = hsmls[mask]
                     else:


### PR DESCRIPTION
In this intermediate Gadget HDF5 refactor: 

* `IOHandlerGadgetHDF5._read_particle_data_file` uses the new `GadgetHDF5File._read_field` method to read fields off disk. 
* `IOHandlerGadgetHDF5._get_smoothing_length` also uses `_read_field` if appropriate but more importantly, it now uses the open file handle if reading the smoothing length from the data_file (if the open handle exists). This removes the potential for opening the file twice if `_get_smoothing_length` is called from `_read_particle_data_file`. 
*  I condensed a lot of the special cases for various fields by adding the `GadgetHDF5File._sanitize_field_col` method. 

The `selector` mask is still generated and applied in `_read_particle_data_file`, which I think is appropriate as it keeps the purpose of the `IOHandlerGadgetHDF5._read_particle_data_file` distinct from `GadgetHDF5File._read_field`  : the io handler manages the reads and applies selector masks while the particle file object provides the directives for how to read from disk for a single file. 

