### PR TITLE
gadget binary using _read_file and related refactoring

### DIFF
--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -2,6 +2,7 @@ import contextlib
 import os
 import stat
 import struct
+from collections import defaultdict
 
 import numpy as np
 
@@ -168,13 +169,39 @@ class GadgetBinaryHeader:
         return True
 
 
-class GadgetBinaryFile(ParticleFile):
+class GadgetParticleFile(ParticleFile):
+    # an intermediate abstract class for both gadget types.
+
+    _file_read_mode = None  # either "r" or "rb", set by child class
+    _opening_func = None  # a function handle for opening the file
+
+    @contextlib.contextmanager
+    def transaction(self, handle=None):
+        if handle is None:
+            handle = self._opening_func(self.filename, mode=self._file_read_mode)
+            yield handle
+            handle.close()
+        else:
+            # we have ended up here recursively, so simply yield. The outer
+            # instance will take care of closing the handle.
+            yield handle
+
+
+class GadgetBinaryFile(GadgetParticleFile):
+
+    _file_read_mode = "rb"
+    _opening_func = open
+
     def __init__(self, ds, io, filename, file_id, range=None):
         header = GadgetBinaryHeader(filename, ds._header.spec)
         self.header = header.value
         self._position_offset = header.position_offset
         with header.open() as f:
             self._file_size = f.seek(0, os.SEEK_END)
+
+        default_field_type = np.dtype(io._endian + ds._header.float_type)
+        self._field_dtype = defaultdict(lambda: default_field_type)
+        self._field_dtype["ParticleIDs"] = np.dtype(io._endian + ds._id_dtype)
 
         super().__init__(ds, io, filename, file_id, range)
 
@@ -188,6 +215,39 @@ class GadgetBinaryFile(ParticleFile):
             self.start,
             self._file_size,
         )
+
+    def _field_count(self, ptype, field):
+        # get the expected array size of the current particle type and field
+        count = self.total_particles[ptype]
+        if field in self.io._vector_fields:
+            count *= self.io._vector_fields[field]
+        return count
+
+    def _read_field(self, ptype, field, handle=None):
+
+        # get the length of the field and the data type
+        count = self._field_count(ptype, field)
+        if count == 0:
+            return
+        dt = self._field_dtype[field]
+
+        # read in the data from the right offset location
+        poffset = self.field_offsets[ptype, field]
+        with self.transaction(handle) as f:
+            f.seek(poffset, os.SEEK_SET)
+            arr = np.fromfile(f, dtype=dt, count=count)
+
+        # ensure data are in native endianness to avoid errors
+        # when field data are passed to cython
+        dt = dt.newbyteorder("N")
+        arr = arr.astype(dt)
+
+        # reshape if we have a vector
+        if field in self.io._vector_fields:
+            factor = self.io._vector_fields[field]
+            arr = arr.reshape((count // factor, factor), order="C")
+
+        return arr
 
 
 class GadgetBinaryIndex(SPHParticleIndex):
@@ -560,8 +620,9 @@ class GadgetDataset(SPHDataset):
         return header.validate()
 
 
-class GadgetHDF5File(ParticleFile):
-
+class GadgetHDF5File(GadgetParticleFile):
+    _file_read_mode = "r"
+    _opening_func = h5py.File
     _fields_with_cols = ("Metallicity_", "PassiveScalars_", "Chemistry_", "GFM_Metals_")
 
     def _read_field(self, ptype, field_name, handle=None):
@@ -572,11 +633,8 @@ class GadgetHDF5File(ParticleFile):
             # TODO: consider returning an empty array here instead of None
             return
 
-        if not handle:
-            with self.transaction as handle:
-                v = handle[f"/{ptype}/{field_name}"][self.start : self.end, ...]
-        else:
-            v = handle[f"/{ptype}/{field_name}"][self.start : self.end, ...]
+        with self.transaction(handle) as f:
+            v = f[f"/{ptype}/{field_name}"][self.start : self.end, ...]
 
         if col is not None:
             # extract the column if appropriate for this field
@@ -600,13 +658,6 @@ class GadgetHDF5File(ParticleFile):
             return "ElementAbundance/" + field_name, None
 
         return field_name, None
-
-    @property
-    @contextlib.contextmanager
-    def transaction(self):
-        handle = h5py.File(self.filename, mode="r")
-        yield handle
-        handle.close()
 
 
 class GadgetHDF5Dataset(GadgetDataset):

--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -172,13 +172,12 @@ class GadgetBinaryHeader:
 class GadgetParticleFile(ParticleFile):
     # an intermediate abstract class for both gadget types.
 
-    _file_read_mode = None  # either "r" or "rb", set by child class
     _opening_func = None  # a function handle for opening the file
 
     @contextlib.contextmanager
     def transaction(self, handle=None):
         if handle is None:
-            handle = self._opening_func(self.filename, mode=self._file_read_mode)
+            handle = self._opening_func(self.filename, mode="r")
             yield handle
             handle.close()
         else:
@@ -189,7 +188,6 @@ class GadgetParticleFile(ParticleFile):
 
 class GadgetBinaryFile(GadgetParticleFile):
 
-    _file_read_mode = "rb"
     _opening_func = open
 
     def __init__(self, ds, io, filename, file_id, range=None):
@@ -621,9 +619,13 @@ class GadgetDataset(SPHDataset):
 
 
 class GadgetHDF5File(GadgetParticleFile):
-    _file_read_mode = "r"
-    _opening_func = h5py.File
     _fields_with_cols = ("Metallicity_", "PassiveScalars_", "Chemistry_", "GFM_Metals_")
+
+    @property
+    def _opening_func(self):
+        # the opening function relies on an optional dependency, so isolate it
+        # here rather than as a class variable
+        return h5py.File
 
     def _read_field(self, ptype, field_name, handle=None):
 

--- a/yt/frontends/gadget/io.py
+++ b/yt/frontends/gadget/io.py
@@ -66,24 +66,17 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
                     yield ptype, (x, y, z), hsml
 
     def _yield_coordinates(self, data_file, needed_ptype=None):
-        si, ei = data_file.start, data_file.end
-        f = h5py.File(data_file.filename, mode="r")
-        pcount = f["/Header"].attrs["NumPart_ThisFile"][:].astype("int")
-        np.clip(pcount - si, 0, ei - si, out=pcount)
-        pcount = pcount.sum()
-        for key in f.keys():
-            if not key.startswith("PartType"):
-                continue
-            if "Coordinates" not in f[key]:
-                continue
-            if needed_ptype and key != needed_ptype:
-                continue
-            ds = f[key]["Coordinates"][si:ei, ...]
-            dt = ds.dtype.newbyteorder("N")  # Native
-            pos = np.empty(ds.shape, dtype=dt)
-            pos[:] = ds
-            yield key, pos
-        f.close()
+        with data_file.transaction() as f:
+            for ptype, count in data_file.total_particles.items():
+                if needed_ptype and ptype != needed_ptype:
+                    continue
+                if count == 0:
+                    continue
+                ds = data_file._read_field(ptype, self._coord_name, handle=f)
+                dt = ds.dtype.newbyteorder("N")  # Native
+                pos = np.empty(ds.shape, dtype=dt)
+                pos[:] = ds
+                yield ptype, pos
 
     def _generate_smoothing_length(self, index):
         data_files = index.data_files
@@ -337,6 +330,7 @@ class IOHandlerGadgetBinary(IOHandlerSPH):
         self._vector_fields = dict(self._vector_fields)
         self._fields = ds._field_spec
         self._ptypes = ds._ptype_spec
+        self._coord_name = ds._particle_coordinates_name
         self.data_files = set()
         gformat, endianswap = ds._header.gadget_format
         # gadget format 1 original, 2 with block name
@@ -365,7 +359,7 @@ class IOHandlerGadgetBinary(IOHandlerSPH):
                     if data_file.total_particles[ptype] == 0:
                         # skip if there are no particles
                         continue
-                    pos = data_file._read_field(ptype, "Coordinates", handle=handle)
+                    pos = data_file._read_field(ptype, self._coord_name, handle=handle)
                     if ptype == self.ds._sph_ptypes[0]:
                         hsml = data_file._read_field(
                             ptype, "SmoothingLength", handle=handle
@@ -384,7 +378,7 @@ class IOHandlerGadgetBinary(IOHandlerSPH):
                 if selector is None or getattr(selector, "is_all_data", False):
                     mask = slice(None, None, None)
                 else:
-                    pos = data_file._read_field(ptype, "Coordinates", handle=f)
+                    pos = data_file._read_field(ptype, self._coord_name, handle=f)
                     if ptype == self.ds._sph_ptypes[0]:
                         hsml = data_file._read_field(ptype, "SmoothingLength", handle=f)
                     else:
@@ -413,17 +407,13 @@ class IOHandlerGadgetBinary(IOHandlerSPH):
     def _yield_coordinates(self, data_file, needed_ptype=None):
         self._float_type = data_file.ds._header.float_type
         self._field_size = np.dtype(self._float_type).itemsize
-        with open(data_file.filename, "rb") as f:
-            # We add on an additionally 4 for the first record.
-            f.seek(data_file._position_offset + 4)
+        with data_file.transaction() as f:
             for ptype, count in data_file.total_particles.items():
                 if count == 0:
                     continue
                 if needed_ptype is not None and ptype != needed_ptype:
                     continue
-                # The first total_particles * 3 values are positions
-                pp = np.fromfile(f, dtype=self._float_type, count=count * 3)
-                pp.shape = (count, 3)
+                pp = data_file._read_field(ptype, self._coord_name, handle=f)
                 yield ptype, pp
 
     def _get_smoothing_length(self, data_file, position_dtype, position_shape):

--- a/yt/frontends/gadget/io.py
+++ b/yt/frontends/gadget/io.py
@@ -46,7 +46,7 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
 
     def _read_particle_coords(self, chunks, ptf):
         for data_file in self._sorted_chunk_iterator(chunks):
-            with data_file.transaction as handle:
+            with data_file.transaction() as handle:
                 # This double-reads
                 for ptype in sorted(ptf):
                     if data_file.total_particles[ptype] == 0:
@@ -58,7 +58,9 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
                     if ptype == self.ds._sph_ptypes[0]:
                         pdtype = c.dtype
                         pshape = c.shape
-                        hsml = self._get_smoothing_length(data_file, pdtype, pshape)
+                        hsml = self._get_smoothing_length(
+                            data_file, pdtype, pshape, handle=handle
+                        )
                     else:
                         hsml = 0.0
                     yield ptype, (x, y, z), hsml
@@ -171,7 +173,7 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
 
         data_return = {}
         cname = self.ds._particle_coordinates_name
-        with data_file.transaction as handle:
+        with data_file.transaction() as handle:
 
             for ptype, field_list in sorted(ptf.items()):
                 if data_file.total_particles[ptype] == 0:
@@ -356,88 +358,57 @@ class IOHandlerGadgetBinary(IOHandlerSPH):
         raise NotImplementedError
 
     def _read_particle_coords(self, chunks, ptf):
-        data_files = set()
-        for chunk in chunks:
-            for obj in chunk.objs:
-                data_files.update(obj.data_files)
-        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
-            poff = data_file.field_offsets
-            tp = data_file.total_particles
-            f = open(data_file.filename, "rb")
-            for ptype in ptf:
-                if tp[ptype] == 0:
-                    # skip if there are no particles
-                    continue
-                f.seek(poff[ptype, "Coordinates"], os.SEEK_SET)
-                pos = self._read_field_from_file(f, tp[ptype], "Coordinates")
-                if ptype == self.ds._sph_ptypes[0]:
-                    f.seek(poff[ptype, "SmoothingLength"], os.SEEK_SET)
-                    hsml = self._read_field_from_file(f, tp[ptype], "SmoothingLength")
-                else:
-                    hsml = 0.0
-                yield ptype, (pos[:, 0], pos[:, 1], pos[:, 2]), hsml
-            f.close()
+
+        for data_file in self._sorted_chunk_iterator(chunks):
+            with data_file.transaction() as handle:
+                for ptype in ptf:
+                    if data_file.total_particles[ptype] == 0:
+                        # skip if there are no particles
+                        continue
+                    pos = data_file._read_field(ptype, "Coordinates", handle=handle)
+                    if ptype == self.ds._sph_ptypes[0]:
+                        hsml = data_file._read_field(
+                            ptype, "SmoothingLength", handle=handle
+                        )
+                    else:
+                        hsml = 0.0
+                    yield ptype, (pos[:, 0], pos[:, 1], pos[:, 2]), hsml
 
     def _read_particle_data_file(self, data_file, ptf, selector=None):
         return_data = {}
-        poff = data_file.field_offsets
-        tp = data_file.total_particles
-        f = open(data_file.filename, "rb")
-        for ptype, field_list in sorted(ptf.items()):
-            if tp[ptype] == 0:
-                continue
-            if selector is None or getattr(selector, "is_all_data", False):
-                mask = slice(None, None, None)
-            else:
-                f.seek(poff[ptype, "Coordinates"], os.SEEK_SET)
-                pos = self._read_field_from_file(f, tp[ptype], "Coordinates")
-                if ptype == self.ds._sph_ptypes[0]:
-                    f.seek(poff[ptype, "SmoothingLength"], os.SEEK_SET)
-                    hsml = self._read_field_from_file(f, tp[ptype], "SmoothingLength")
-                else:
-                    hsml = 0.0
-                mask = selector.select_points(pos[:, 0], pos[:, 1], pos[:, 2], hsml)
-                del pos
-                del hsml
-            if mask is None:
-                continue
-            for field in field_list:
-                if field == "Mass" and ptype not in self.var_mass:
-                    if getattr(selector, "is_all_data", False):
-                        size = data_file.total_particles[ptype]
-                    else:
-                        size = mask.sum()
-                    data = np.empty(size, dtype="float64")
-                    m = self.ds.parameters["Massarr"][self._ptypes.index(ptype)]
-                    data[:] = m
-                    yield (ptype, field), data
-                    continue
-                f.seek(poff[ptype, field], os.SEEK_SET)
-                data = self._read_field_from_file(f, tp[ptype], field)
-                data = data[mask, ...]
-                return_data[(ptype, field)] = data
-        f.close()
-        return return_data
 
-    def _read_field_from_file(self, f, count, name):
-        if count == 0:
-            return
-        if name == "ParticleIDs":
-            dt = self._endian + self.ds._id_dtype
-        else:
-            dt = self._endian + self._float_type
-        dt = np.dtype(dt)
-        if name in self._vector_fields:
-            count *= self._vector_fields[name]
-        arr = np.fromfile(f, dtype=dt, count=count)
-        # ensure data are in native endianness to avoid errors
-        # when field data are passed to cython
-        dt = dt.newbyteorder("N")
-        arr = arr.astype(dt)
-        if name in self._vector_fields:
-            factor = self._vector_fields[name]
-            arr = arr.reshape((count // factor, factor), order="C")
-        return arr
+        with data_file.transaction() as f:
+            for ptype, field_list in sorted(ptf.items()):
+                if data_file.total_particles[ptype] == 0:
+                    continue
+                if selector is None or getattr(selector, "is_all_data", False):
+                    mask = slice(None, None, None)
+                else:
+                    pos = data_file._read_field(ptype, "Coordinates", handle=f)
+                    if ptype == self.ds._sph_ptypes[0]:
+                        hsml = data_file._read_field(ptype, "SmoothingLength", handle=f)
+                    else:
+                        hsml = 0.0
+                    mask = selector.select_points(pos[:, 0], pos[:, 1], pos[:, 2], hsml)
+                    del pos
+                    del hsml
+                if mask is None:
+                    continue
+                for field in field_list:
+                    if field == "Mass" and ptype not in self.var_mass:
+                        if getattr(selector, "is_all_data", False):
+                            size = data_file.total_particles[ptype]
+                        else:
+                            size = mask.sum()
+                        data = np.empty(size, dtype="float64")
+                        m = self.ds.parameters["Massarr"][self._ptypes.index(ptype)]
+                        data[:] = m
+                        return_data[(ptype, field)] = data
+                        continue
+                    data = data_file._read_field(ptype, field, handle=f)
+                    data = data[mask, ...]
+                    return_data[(ptype, field)] = data
+        return return_data
 
     def _yield_coordinates(self, data_file, needed_ptype=None):
         self._float_type = data_file.ds._header.float_type
@@ -466,12 +437,7 @@ class IOHandlerGadgetBinary(IOHandlerSPH):
         return ret
 
     def _get_field(self, data_file, field, ptype):
-        poff = data_file.field_offsets
-        tp = data_file.total_particles
-        with open(data_file.filename, "rb") as f:
-            f.seek(poff[ptype, field], os.SEEK_SET)
-            pp = self._read_field_from_file(f, tp[ptype], field)
-        return pp
+        return data_file._read_field(ptype, field)
 
     def _count_particles(self, data_file):
         si, ei = data_file.start, data_file.end

--- a/yt/frontends/gadget_fof/io.py
+++ b/yt/frontends/gadget_fof/io.py
@@ -19,12 +19,7 @@ class IOHandlerGadgetFOFHDF5(BaseParticleIOHandler):
 
     def _read_particle_coords(self, chunks, ptf):
         # This will read chunks and yield the results.
-        chunks = list(chunks)
-        data_files = set()
-        for chunk in chunks:
-            for obj in chunk.objs:
-                data_files.update(obj.data_files)
-        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
+        for data_file in self._sorted_chunk_iterator(chunks):
             with h5py.File(data_file.filename, mode="r") as f:
                 for ptype in sorted(ptf):
                     coords = data_file._get_particle_positions(ptype, f=f)
@@ -69,12 +64,7 @@ class IOHandlerGadgetFOFHDF5(BaseParticleIOHandler):
 
     def _read_particle_fields(self, chunks, ptf, selector):
         # Now we have all the sizes, and we can allocate
-        chunks = list(chunks)
-        data_files = set()
-        for chunk in chunks:
-            for obj in chunk.objs:
-                data_files.update(obj.data_files)
-        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
+        for data_file in self._sorted_chunk_iterator(chunks):
             si, ei = data_file.start, data_file.end
             with h5py.File(data_file.filename, mode="r") as f:
                 for ptype, field_list in sorted(ptf.items()):

--- a/yt/frontends/halo_catalog/io.py
+++ b/yt/frontends/halo_catalog/io.py
@@ -17,17 +17,12 @@ class IOHandlerYTHaloCatalog(BaseParticleIOHandler):
 
     def _read_particle_coords(self, chunks, ptf):
         # This will read chunks and yield the results.
-        chunks = list(chunks)
-        data_files = set()
         # Only support halo reading for now.
         assert len(ptf) == 1
         assert list(ptf.keys())[0] == "halos"
         ptype = "halos"
-        for chunk in chunks:
-            for obj in chunk.objs:
-                data_files.update(obj.data_files)
         pn = "particle_position_%s"
-        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
+        for data_file in self._sorted_chunk_iterator(chunks):
             with h5py.File(data_file.filename, mode="r") as f:
                 units = parse_h5_attr(f[pn % "x"], "units")
                 pos = data_file._get_particle_positions(ptype, f=f)
@@ -47,16 +42,11 @@ class IOHandlerYTHaloCatalog(BaseParticleIOHandler):
 
     def _read_particle_fields(self, chunks, ptf, selector):
         # Now we have all the sizes, and we can allocate
-        chunks = list(chunks)
-        data_files = set()
         # Only support halo reading for now.
         assert len(ptf) == 1
         assert list(ptf.keys())[0] == "halos"
-        for chunk in chunks:
-            for obj in chunk.objs:
-                data_files.update(obj.data_files)
         pn = "particle_position_%s"
-        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
+        for data_file in self._sorted_chunk_iterator(chunks):
             si, ei = data_file.start, data_file.end
             with h5py.File(data_file.filename, mode="r") as f:
                 for ptype, field_list in sorted(ptf.items()):

--- a/yt/frontends/http_stream/io.py
+++ b/yt/frontends/http_stream/io.py
@@ -33,12 +33,7 @@ class IOHandlerHTTPStream(BaseParticleIOHandler):
         return f, {}
 
     def _read_particle_coords(self, chunks, ptf):
-        chunks = list(chunks)
-        data_files = set()
-        for chunk in chunks:
-            for obj in chunk.objs:
-                data_files.update(obj.data_files)
-        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
+        for data_file in self._sorted_chunk_iterator(chunks):
             for ptype in ptf:
                 s = self._open_stream(data_file, (ptype, "Coordinates"))
                 c = np.frombuffer(s, dtype="float64")
@@ -47,11 +42,7 @@ class IOHandlerHTTPStream(BaseParticleIOHandler):
 
     def _read_particle_fields(self, chunks, ptf, selector):
         # Now we have all the sizes, and we can allocate
-        data_files = set()
-        for chunk in chunks:
-            for obj in chunk.objs:
-                data_files.update(obj.data_files)
-        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
+        for data_file in self._sorted_chunk_iterator(chunks):
             for ptype, field_list in sorted(ptf.items()):
                 s = self._open_stream(data_file, (ptype, "Coordinates"))
                 c = np.frombuffer(s, dtype="float64")

--- a/yt/frontends/owls_subfind/io.py
+++ b/yt/frontends/owls_subfind/io.py
@@ -20,12 +20,7 @@ class IOHandlerOWLSSubfindHDF5(BaseParticleIOHandler):
 
     def _read_particle_coords(self, chunks, ptf):
         # This will read chunks and yield the results.
-        chunks = list(chunks)
-        data_files = set()
-        for chunk in chunks:
-            for obj in chunk.objs:
-                data_files.update(obj.data_files)
-        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
+        for data_file in self._sorted_chunk_iterator(chunks):
             with h5py.File(data_file.filename, mode="r") as f:
                 for ptype in sorted(ptf):
                     pcount = data_file.total_particles[ptype]
@@ -67,12 +62,7 @@ class IOHandlerOWLSSubfindHDF5(BaseParticleIOHandler):
 
     def _read_particle_fields(self, chunks, ptf, selector):
         # Now we have all the sizes, and we can allocate
-        chunks = list(chunks)
-        data_files = set()
-        for chunk in chunks:
-            for obj in chunk.objs:
-                data_files.update(obj.data_files)
-        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
+        for data_file in self._sorted_chunk_iterator(chunks):
             with h5py.File(data_file.filename, mode="r") as f:
                 for ptype, field_list in sorted(ptf.items()):
                     pcount = data_file.total_particles[ptype]

--- a/yt/frontends/rockstar/io.py
+++ b/yt/frontends/rockstar/io.py
@@ -19,16 +19,11 @@ class IOHandlerRockstarBinary(BaseParticleIOHandler):
 
     def _read_particle_coords(self, chunks, ptf):
         # This will read chunks and yield the results.
-        chunks = list(chunks)
-        data_files = set()
         # Only support halo reading for now.
         assert len(ptf) == 1
         assert list(ptf.keys())[0] == "halos"
         ptype = "halos"
-        for chunk in chunks:
-            for obj in chunk.objs:
-                data_files.update(obj.data_files)
-        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
+        for data_file in self._sorted_chunk_iterator(chunks):
             pcount = data_file.header["num_halos"]
             if pcount == 0:
                 continue
@@ -38,15 +33,10 @@ class IOHandlerRockstarBinary(BaseParticleIOHandler):
 
     def _read_particle_fields(self, chunks, ptf, selector):
         # Now we have all the sizes, and we can allocate
-        chunks = list(chunks)
-        data_files = set()
         # Only support halo reading for now.
         assert len(ptf) == 1
         assert list(ptf.keys())[0] == "halos"
-        for chunk in chunks:
-            for obj in chunk.objs:
-                data_files.update(obj.data_files)
-        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
+        for data_file in self._sorted_chunk_iterator(chunks):
             si, ei = data_file.start, data_file.end
             pcount = data_file.header["num_halos"]
             if pcount == 0:

--- a/yt/frontends/sdf/io.py
+++ b/yt/frontends/sdf/io.py
@@ -14,16 +14,15 @@ class IOHandlerSDF(BaseParticleIOHandler):
     def _read_fluid_selection(self, chunks, selector, fields, size):
         raise NotImplementedError
 
+    def _sorted_chunk_iterator(self, chunks):
+        data_files = list(super()._sorted_chunk_iterator(chunks))
+        assert len(data_files) == 1
+        yield from data_files
+
     def _read_particle_coords(self, chunks, ptf):
-        chunks = list(chunks)
-        data_files = set()
         assert len(ptf) == 1
         assert ptf.keys()[0] == "dark_matter"
-        for chunk in chunks:
-            for obj in chunk.objs:
-                data_files.update(obj.data_files)
-        assert len(data_files) == 1
-        for _data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
+        for _data_file in self._sorted_chunk_iterator(chunks):
             yield "dark_matter", (
                 self._handle["x"],
                 self._handle["y"],
@@ -31,15 +30,9 @@ class IOHandlerSDF(BaseParticleIOHandler):
             ), 0.0
 
     def _read_particle_fields(self, chunks, ptf, selector):
-        chunks = list(chunks)
-        data_files = set()
         assert len(ptf) == 1
         assert ptf.keys()[0] == "dark_matter"
-        for chunk in chunks:
-            for obj in chunk.objs:
-                data_files.update(obj.data_files)
-        assert len(data_files) == 1
-        for _data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
+        for _data_file in self._sorted_chunk_iterator(chunks):
             for ptype, field_list in sorted(ptf.items()):
                 x = self._handle["x"]
                 y = self._handle["y"]

--- a/yt/frontends/stream/io.py
+++ b/yt/frontends/stream/io.py
@@ -97,9 +97,7 @@ class StreamParticleIOHandler(BaseParticleIOHandler):
         super().__init__(ds)
 
     def _read_particle_coords(self, chunks, ptf):
-        for data_file in sorted(
-            self._get_data_files(chunks), key=lambda x: (x.filename, x.start)
-        ):
+        for data_file in self._sorted_chunk_iterator(chunks):
             f = self.fields[data_file.filename]
             # This double-reads
             for ptype in sorted(ptf):
@@ -110,18 +108,9 @@ class StreamParticleIOHandler(BaseParticleIOHandler):
                 ), 0.0
 
     def _read_smoothing_length(self, chunks, ptf, ptype):
-        for data_file in sorted(
-            self._get_data_files(chunks), key=lambda x: (x.filename, x.start)
-        ):
+        for data_file in self._sorted_chunk_iterator(chunks):
             f = self.fields[data_file.filename]
             return f[ptype, "smoothing_length"]
-
-    def _get_data_files(self, chunks):
-        data_files = set()
-        for chunk in chunks:
-            for obj in chunk.objs:
-                data_files.update(obj.data_files)
-        return data_files
 
     def _count_particles_chunks(self, psize, chunks, ptf, selector):
         for ptype, (x, y, z), _ in self._read_particle_coords(chunks, ptf):

--- a/yt/frontends/tipsy/io.py
+++ b/yt/frontends/tipsy/io.py
@@ -86,12 +86,9 @@ class IOHandlerTipsyBinary(IOHandlerSPH):
         return rv
 
     def _read_particle_coords(self, chunks, ptf):
-        data_files = set()
-        for chunk in chunks:
-            for obj in chunk.objs:
-                data_files.update(obj.data_files)
+
         chunksize = self.ds.index.chunksize
-        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
+        for data_file in self._sorted_chunk_iterator(chunks):
             poff = data_file.field_offsets
             tp = data_file.total_particles
             f = open(data_file.filename, "rb")

--- a/yt/utilities/io_handler.py
+++ b/yt/utilities/io_handler.py
@@ -256,22 +256,13 @@ class BaseIOHandler:
 
     def _read_particle_fields(self, chunks, ptf, selector):
         # Now we have all the sizes, and we can allocate
-        data_files = set()
-        for chunk in chunks:
-            for obj in chunk.objs:
-                data_files.update(obj.data_files)
-        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
+        for data_file in self._sorted_chunk_iterator(chunks):
             data_file_data = self._read_particle_data_file(data_file, ptf, selector)
             # temporary trickery so it's still an iterator, need to adjust
             # the io_handler.BaseIOHandler.read_particle_selection() method
             # to not use an iterator.
             yield from data_file_data.items()
 
-
-# As a note: we don't *actually* want this to be how it is forever.  There's no
-# reason we need to have the fluid and particle IO handlers separated.  But,
-# for keeping track of which frontend is which, this is a useful abstraction.
-class BaseParticleIOHandler(BaseIOHandler):
     def _sorted_chunk_iterator(self, chunks):
         chunks = list(chunks)
         data_files = set()
@@ -280,6 +271,11 @@ class BaseParticleIOHandler(BaseIOHandler):
                 data_files.update(obj.data_files)
         yield from sorted(data_files, key=lambda x: (x.filename, x.start))
 
+
+# As a note: we don't *actually* want this to be how it is forever.  There's no
+# reason we need to have the fluid and particle IO handlers separated.  But,
+# for keeping track of which frontend is which, this is a useful abstraction.
+class BaseParticleIOHandler(BaseIOHandler):
     def _count_particles_chunks(
         self, psize: ParticleTypeSizes, chunks, ptf: ParticleTypeFields, selector
     ) -> ParticleTypeSizes:


### PR DESCRIPTION
This PR follows up to the previous PR that got the gadget hdf io working with the new `ParticleFile` framework. Now for the binary format!

It mostly follows the previous PR, but there are a few things to point out:

I created an intermediate `GadgetParticleFile` class that both `GadgetBinaryFile` and `GadgetHDF5File` now inherit from. I did this so the `.transaction` attribute can be defined in one place. 

Related to the `.transaction` attribute, I was trying to cut down on copy/paste that came from checking if the `handle` existed. Previously, we had code like this:

```
if not handle:
	with self.transaction as handle:
		use handle to read
else:
	use handle to read
```
So I changed `self.transaction` from a property to a function that accepts a `handle` argument and `yields` it again if it exists. It seems to work fine... but I'm a little worried about whether it's safe from a context managing perspective? It may be a bad idea, but it changes the above 5 lines to:

```
with self.transaction(handle) as fhandle:
		use fhandle to read
```

Totally happy to roll back those changes if needed!