### PR TITLE
add a cache toggle

### DIFF
--- a/yt/data_objects/index_subobjects/grid_patch.py
+++ b/yt/data_objects/index_subobjects/grid_patch.py
@@ -156,6 +156,9 @@ class AMRGridPatch(YTSelectionContainer):
         """
         super().clear_data()
         self._setup_dx()
+        self._last_mask = None
+        self._last_count = -1
+        self._last_selector_id = None
 
     def _prepare_grid(self):
         """Copies all the appropriate attributes from the index."""

--- a/yt/geometry/grid_geometry_handler.py
+++ b/yt/geometry/grid_geometry_handler.py
@@ -106,7 +106,7 @@ class GridIndex(Index, abc.ABC):
             g.clear_data()
         self.io.queue.clear()
 
-    def set_grid_cache_mask(self, cache_grid_masks, clear_all_data=True):
+    def _set_grid_cache_mask(self, cache_grid_masks, clear_all_data=True):
         """
         This routine turns on/off the cache for grid masks for each grid,
         optionally clearing all data first.

--- a/yt/geometry/grid_geometry_handler.py
+++ b/yt/geometry/grid_geometry_handler.py
@@ -106,7 +106,7 @@ class GridIndex(Index, abc.ABC):
             g.clear_data()
         self.io.queue.clear()
 
-    def set_grid_cache_mask(self, cache_grid_masks: bool, clear_all_data: bool = True):
+    def set_grid_cache_mask(self, cache_grid_masks, clear_all_data=True):
         """
         This routine turns on/off the cache for grid masks for each grid,
         optionally clearing all data first.

--- a/yt/geometry/grid_geometry_handler.py
+++ b/yt/geometry/grid_geometry_handler.py
@@ -106,6 +106,27 @@ class GridIndex(Index, abc.ABC):
             g.clear_data()
         self.io.queue.clear()
 
+    def set_grid_cache_mask(self, cache_grid_masks: bool, clear_all_data: bool = True):
+        """
+        This routine turns on/off the cache for grid masks for each grid,
+        optionally clearing all data first.
+
+        Parameters
+        ----------
+        cache_grid_masks: bool
+            If True, selection masks will be cached by each grid object. If
+            False, selection masks will be rebuilt as needed.
+        clear_all_data: bool
+            If True (the default), will call clear_all_data()
+
+        """
+        if clear_all_data:
+            self.clear_all_data()
+
+        mylog.info(f"Setting _cache_mask for all grids to {cache_grid_masks}")
+        for g in self.grids:
+            g._cache_mask = cache_grid_masks
+
     def get_smallest_dx(self):
         """
         Returns (in code units) the smallest cell size in the simulation.

--- a/yt/geometry/tests/test_grid_container.py
+++ b/yt/geometry/tests/test_grid_container.py
@@ -149,10 +149,10 @@ def test_grid_cache_toggle():
     _ = ds.find_max("density")
     assert ds.index.grids[0]._last_mask is not None
 
-    ds.index.set_grid_cache_mask(False, clear_all_data=False)
+    ds.index._set_grid_cache_mask(False, clear_all_data=False)
     assert ds.index.grids[0]._last_mask is not None
 
-    ds.index.set_grid_cache_mask(False, clear_all_data=True)
+    ds.index._set_grid_cache_mask(False, clear_all_data=True)
     assert ds.index.grids[0]._last_mask is None
     _ = ds.find_max("density")
     assert ds.index.grids[0]._last_mask is None

--- a/yt/geometry/tests/test_grid_container.py
+++ b/yt/geometry/tests/test_grid_container.py
@@ -142,3 +142,17 @@ def test_grid_arrays_view():
     assert_equal(grid_arr["right_edge"], ds.index.grid_right_edge)
     assert_equal(grid_arr["dims"], ds.index.grid_dimensions)
     assert_equal(grid_arr["level"], ds.index.grid_levels[:, 0])
+
+
+def test_grid_cache_toggle():
+    ds = setup_test_ds()
+    _ = ds.find_max("density")
+    assert ds.index.grids[0]._last_mask is not None
+
+    ds.index.set_grid_cache_mask(False, clear_all_data=False)
+    assert ds.index.grids[0]._last_mask is not None
+
+    ds.index.set_grid_cache_mask(False, clear_all_data=True)
+    assert ds.index.grids[0]._last_mask is None
+    _ = ds.find_max("density")
+    assert ds.index.grids[0]._last_mask is None


### PR DESCRIPTION
This is mostly for testing purposes, but maybe it'd be useful to include in the actual PR? 

This PR adds a way to toggle the mask cache behavior for all the grids, the following would turn off/on cacheing:

```
ds = yt.load(...)
ds.index.set_grid_cache_mask(False) # Turn off
ds.index.set_grid_cache_mask(True) # Turn on
```
It includes an optional parameter, `clear_all_data` (default is `True`) to calls `clear_all_data()` if True. 